### PR TITLE
Use requests session to recycle HTTP connections

### DIFF
--- a/deepomatic/client.py
+++ b/deepomatic/client.py
@@ -38,11 +38,11 @@ API_HOST = 'https://api.deepomatic.com'
 
 class Client(object):
 
-    def __init__(self, app_id=None, api_key=None, verify_ssl=True, check_query_parameters=True, host=None, version=API_VERSION, user_agent_suffix=''):
+    def __init__(self, app_id=None, api_key=None, verify_ssl=True, check_query_parameters=True, host=None, version=API_VERSION, user_agent_suffix='', pool_maxsize=50):
         if host is None:
             host = API_HOST
 
-        self.http_helper = HTTPHelper(app_id, api_key, verify_ssl, host, version, check_query_parameters, user_agent_suffix)
+        self.http_helper = HTTPHelper(app_id, api_key, verify_ssl, host, version, check_query_parameters, user_agent_suffix, pool_maxsize)
 
         # /accounts
 

--- a/deepomatic/client.py
+++ b/deepomatic/client.py
@@ -38,7 +38,7 @@ API_HOST = 'https://api.deepomatic.com'
 
 class Client(object):
 
-    def __init__(self, app_id=None, api_key=None, verify_ssl=True, check_query_parameters=True, host=None, version=API_VERSION, user_agent_suffix='', pool_maxsize=50):
+    def __init__(self, app_id=None, api_key=None, verify_ssl=True, check_query_parameters=True, host=None, version=API_VERSION, user_agent_suffix='', pool_maxsize=20):
         if host is None:
             host = API_HOST
 

--- a/deepomatic/http_helper.py
+++ b/deepomatic/http_helper.py
@@ -37,7 +37,7 @@ from deepomatic.version import __VERSION__
 
 
 class HTTPHelper(object):
-    def __init__(self, app_id, api_key, verify, host, version, check_query_parameters, user_agent_suffix='', pool_maxsize=50):
+    def __init__(self, app_id, api_key, verify, host, version, check_query_parameters, user_agent_suffix='', pool_maxsize=20):
         """
         Init the HTTP helper with API key and secret
         """
@@ -86,7 +86,8 @@ class HTTPHelper(object):
         self.session.headers.update(headers)
         # Use pool_maxsize to cache connections for the same host
         adapter = requests.adapters.HTTPAdapter(pool_maxsize=pool_maxsize)
-        self.session.mount('http', adapter)
+        self.session.mount('http://', adapter)
+        self.session.mount('https://', adapter)
 
     def setup_headers(self, headers=None, content_type=None):
         """

--- a/deepomatic/http_helper.py
+++ b/deepomatic/http_helper.py
@@ -37,7 +37,7 @@ from deepomatic.version import __VERSION__
 
 
 class HTTPHelper(object):
-    def __init__(self, app_id, api_key, verify, host, version, check_query_parameters, user_agent_suffix='', pool_maxsize=100):
+    def __init__(self, app_id, api_key, verify, host, version, check_query_parameters, user_agent_suffix='', pool_maxsize=50):
         """
         Init the HTTP helper with API key and secret
         """

--- a/deepomatic/http_helper.py
+++ b/deepomatic/http_helper.py
@@ -82,7 +82,7 @@ class HTTPHelper(object):
             'X-APP-ID': self.app_id,
             'X-API-KEY': self.api_key,
         }
-        self.session = requests.session()
+        self.session = requests.Session()
         self.session.headers.update(headers)
         # Use pool_maxsize to cache connections for the same host
         adapter = requests.adapters.HTTPAdapter(pool_maxsize=pool_maxsize)

--- a/deepomatic/http_helper.py
+++ b/deepomatic/http_helper.py
@@ -37,7 +37,7 @@ from deepomatic.version import __VERSION__
 
 
 class HTTPHelper(object):
-    def __init__(self, app_id, api_key, verify, host, version, check_query_parameters, user_agent_suffix='', pool_connections=100, pool_maxsize=100):
+    def __init__(self, app_id, api_key, verify, host, version, check_query_parameters, user_agent_suffix='', pool_maxsize=100):
         """
         Init the HTTP helper with API key and secret
         """
@@ -83,7 +83,8 @@ class HTTPHelper(object):
             'X-API-KEY': self.api_key,
         }
         self.session = requests.Session(headers=headers)
-        adapter = requests.adapters.HTTPAdapter(pool_connections=pool_connections, pool_maxsize=pool_maxsize)
+        # Use pool_maxsize to cache connections for the same host
+        adapter = requests.adapters.HTTPAdapter(pool_maxsize=pool_maxsize)
         self.session.mount('http', adapter)
 
     def setup_headers(self, headers=None, content_type=None):

--- a/deepomatic/http_helper.py
+++ b/deepomatic/http_helper.py
@@ -37,7 +37,7 @@ from deepomatic.version import __VERSION__
 
 
 class HTTPHelper(object):
-    def __init__(self, app_id, api_key, verify, host, version, check_query_parameters, user_agent_suffix=''):
+    def __init__(self, app_id, api_key, verify, host, version, check_query_parameters, user_agent_suffix='', pool_connections=100, pool_maxsize=100):
         """
         Init the HTTP helper with API key and secret
         """
@@ -77,9 +77,18 @@ class HTTPHelper(object):
         self.resource_prefix = host + version
         self.check_query_parameters = check_query_parameters
 
+        headers = {
+            'User-Agent': self.user_agent,
+            'X-APP-ID': self.app_id,
+            'X-API-KEY': self.api_key,
+        }
+        self.session = requests.Session(headers=headers)
+        adapter = requests.adapters.HTTPAdapter(pool_connections=pool_connections, pool_maxsize=pool_maxsize)
+        self.session.mount('http', adapter)
+
     def setup_headers(self, headers=None, content_type=None):
         """
-        Build authentification header
+        Build additional headers header
         """
         if headers is None:
             headers = CaseInsensitiveDict()
@@ -90,10 +99,6 @@ class HTTPHelper(object):
             headers['Content-Type'] = content_type
             if 'Accept' not in headers:
                 headers['Accept'] = content_type
-
-        headers['User-Agent'] = self.user_agent
-        headers['X-APP-ID'] = self.app_id
-        headers['X-API-KEY'] = self.api_key
 
         return headers
 
@@ -136,7 +141,7 @@ class HTTPHelper(object):
             files = None
         return new_data, files
 
-    def make_request(self, func, resource, params, data=None, content_type=None, files=None, stream=False):
+    def make_request(self, func, resource, params, data=None, content_type=None, files=None, stream=False, *args, **kwargs):
         if isinstance(data, dict) or isinstance(data, list):
             if content_type.strip() == 'application/json':
                 data = json.dumps(data)
@@ -165,7 +170,7 @@ class HTTPHelper(object):
 
         if not resource.startswith('http'):
             resource = self.resource_prefix + resource
-        response = func(resource, params=params, data=data, files=files, headers=headers, verify=self.verify, stream=stream)
+        response = func(resource, params=params, data=data, files=files, headers=headers, verify=self.verify, *args, **kwargs)
 
         # Close opened files
         for file in opened_files:
@@ -190,31 +195,31 @@ class HTTPHelper(object):
         """
         Perform a GET request
         """
-        return self.make_request(requests.get, resource, params)
+        return self.make_request(self.session.get, resource, params)
 
     def delete(self, resource, params=None):
         """
         Perform a DELETE request
         """
-        return self.make_request(requests.delete, resource, params)
+        return self.make_request(self.session.delete, resource, params)
 
     def post(self, resource, params=None, data=None, content_type='application/json', files=None):
         """
         Perform a POST request
         """
-        return self.make_request(requests.post, resource, params, data, content_type, files)
+        return self.make_request(self.session.post, resource, params, data, content_type, files)
 
     def put(self, resource, params=None, data=None, content_type='application/json', files=None):
         """
         Perform a PUT request
         """
-        return self.make_request(requests.put, resource, params, data, content_type, files)
+        return self.make_request(self.session.put, resource, params, data, content_type, files)
 
     def patch(self, resource, params=None, data=None, content_type='application/json', files=None):
         """
         Perform a PATCH request
         """
-        return self.make_request(requests.patch, resource, params, data, content_type, files)
+        return self.make_request(self.session.patch, resource, params, data, content_type, files)
 
 
 ###############################################################################

--- a/deepomatic/http_helper.py
+++ b/deepomatic/http_helper.py
@@ -172,7 +172,7 @@ class HTTPHelper(object):
 
         if not resource.startswith('http'):
             resource = self.resource_prefix + resource
-        response = func(resource, params=params, data=data, files=files, headers=headers, verify=self.verify, *args, **kwargs)
+        response = func(resource, params=params, data=data, files=files, headers=headers, verify=self.verify, stream=stream, *args, **kwargs)
 
         # Close opened files
         for file in opened_files:

--- a/deepomatic/http_helper.py
+++ b/deepomatic/http_helper.py
@@ -82,7 +82,8 @@ class HTTPHelper(object):
             'X-APP-ID': self.app_id,
             'X-API-KEY': self.api_key,
         }
-        self.session = requests.Session(headers=headers)
+        self.session = requests.session()
+        self.session.headers.update(headers)
         # Use pool_maxsize to cache connections for the same host
         adapter = requests.adapters.HTTPAdapter(pool_maxsize=pool_maxsize)
         self.session.mount('http', adapter)

--- a/deepomatic/http_helper.py
+++ b/deepomatic/http_helper.py
@@ -88,7 +88,7 @@ class HTTPHelper(object):
 
     def setup_headers(self, headers=None, content_type=None):
         """
-        Build additional headers header
+        Build additional headers
         """
         if headers is None:
             headers = CaseInsensitiveDict()


### PR DESCRIPTION
Related to #21 

With requests sessions we now have one HTTP connection pool per deepomatic `Client`, using HTTP keep-alive.

Previously each call to the `Client` created (and closed) a new HTTP connection, including `Task` polling via `wait`. This resulted in a lot of connection churn, potentially saturating the TCP stack.

More info there
https://laike9m.com/blog/requests-secret-pool_connections-and-pool_maxsize,89/