### PR TITLE
Dependency constraints relaxation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.10
 promise>=2.1,<3
-six==1.10.0,<2
-requests==2.11.1,<3
-tenacity==4.12.0,<5
+six>=1.10.0,<2
+requests>=2.11.1,<3
+tenacity>=4.12.0,<5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.10
-promise==2.1
-six==1.10.0
-requests==2.11.1
-tenacity==4.12.0
+promise>=2.1,<3
+six==1.10.0,<2
+requests==2.11.1,<3
+tenacity==4.12.0,<5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.10
+numpy>=1.10,<2
 promise>=2.1,<3
 six>=1.10.0,<2
 requests>=2.11.1,<3


### PR DESCRIPTION
Today, we freeze a very specific version of the imported modules.
This means we can't use the client with another module that requires higher versions.
To mitigate this, we allow any higher module as long as it's not a major change.