### PR TITLE
Better dmake integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+Dockerfile
+.git
+.dockerignore
+Jenkinsfile
+
+build/
+dist/
+
+**/*~
+**/.#*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *.pyc
 /venv*
+
+build/
+dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+ARG BASE_IMAGE
+
+FROM ${BASE_IMAGE} as builder
+
+WORKDIR /app
+COPY . .
+RUN python setup.py bdist_wheel
+
+
+FROM ${BASE_IMAGE} as runtime
+
+# copy egg
+COPY --from=builder /app/dist/deepomatic-*.whl /tmp/
+COPY --from=builder /app/demo.py /samples/
+
+RUN pip install /tmp/deepomatic-*.whl

--- a/dmake.yml
+++ b/dmake.yml
@@ -13,14 +13,35 @@ env:
 
 docker:
   base_image:
+    # This first item is a YAML template named "base_image"
+    # You can reuse it and override just some values with
+    # "- <<: *base_image" as used below.
+    - &base_image
       name: deepomatic-client-python
-      root_image: ubuntu:17.10
-      install_scripts:
-        - tests/install_virtualenv.sh
-
+      variant: 2.7
+      root_image: python:2.7
+    # Nothing changes comparing to above, except 'variant' and 'root_image'
+    - <<: *base_image
+      variant: 3.4
+      root_image: python:3.4
+    - <<: *base_image
+      variant: 3.5
+      root_image: python:3.5
+    - <<: *base_image
+      variant: 3.6
+      root_image: python:3.6
 
 services:
   - service_name: client
+    config:
+      docker_image:
+        build: .
+        base_image_variant:
+          - 2.7
+          - 3.4
+          - 3.5
+          - 3.6
+
     tests:
       commands:
-        - tests/test_demo.sh
+        - python /samples/demo.py


### PR DESCRIPTION
- use base_image_variants to test different python versions
- use multi stage build to really test the `demo.py` outside of the source directory
- git ignore the build artifacts 