### PR TITLE
requests < 2.19 doesn't handle well bytes as multipart in python3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.10,<2
 promise>=2.1,<3
 six>=1.10.0,<2
-requests>=2.11.1,<3
+requests>=2.19.0,<3  # will not work below in python3
 tenacity>=4.12.0,<5


### PR DESCRIPTION
Note: It works in python2 with requests below 2.19 