### PR TITLE
Add MANIFEST.in for packaging via sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
Packaging via 'python setup.py sdist' is required to install the client in CloudML until we register the client on PyPI. The `sdist` command needs a MANIFEST to properly include all source files.