### PR TITLE
Add the capacity to specify post-processings directly on network

### DIFF
--- a/deepomatic/mixins.py
+++ b/deepomatic/mixins.py
@@ -40,8 +40,8 @@ class RequiredArg(Arg):
 
 
 class OptionnalArg(Arg):
-    def __init__(self):
-        super(OptionnalArg, self).__init__(None, True)
+    def __init__(self, mutable=True):
+        super(OptionnalArg, self).__init__(None, mutable)
 
 
 class ImmutableArg(Arg):

--- a/deepomatic/resources/network.py
+++ b/deepomatic/resources/network.py
@@ -48,7 +48,7 @@ class Network(ListableResource,
         'metadata':      OptionnalArg(),
         'framework':     ImmutableArg(),
         'preprocessing': ImmutableArg(),
-        'postprocessing': ImmutableArg(),
+        'postprocessings': OptionnalArg(mutable=False),
     }
 
     @classmethod

--- a/deepomatic/resources/network.py
+++ b/deepomatic/resources/network.py
@@ -48,6 +48,7 @@ class Network(ListableResource,
         'metadata':      OptionnalArg(),
         'framework':     ImmutableArg(),
         'preprocessing': ImmutableArg(),
+        'postprocessing': ImmutableArg(),
     }
 
     @classmethod


### PR DESCRIPTION
The API has been modified so that the new post-processing field can be set either automatically when creating a recognition version or directly when creating the network. This PR adds this last possibility.