### PR TITLE
Retry http errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ install:
 
 # command to run tests
 script:
-  - pip install pytest==4.0.2 pytest-voluptuous==1.1.0 # for testing
+  - pip install pytest==4.0.2 pytest-voluptuous==1.1.0 httpretty==0.9.6 # for testing
   - LOG_LEVEL=DEBUG python -m pytest --junit-xml=junit.xml -vv app/tests
   - LOG_LEVEL=DEBUG python app/demo.py

--- a/deepomatic/api/__init__.py
+++ b/deepomatic/api/__init__.py
@@ -1,1 +1,3 @@
 from deepomatic.api.version import __version__
+
+__all__ = ["__version__"]

--- a/deepomatic/api/client.py
+++ b/deepomatic/api/client.py
@@ -67,7 +67,7 @@ class Client(object):
            :type requests_timeout: float or tuple(float, float)
            :param http_retry (optional): Customize the retry of http errors.
                Defaults to `HTTPRetry()`. Check out `http_retry.HTTPRetry` documentation for more information about the parameters and default values.
-               If None, no retry will be done on errors.
+               If `None`, no retry will be done on errors.
            :type http_retry: http_retry.HTTPRetry
 
            :return: :class:`Client` object

--- a/deepomatic/api/client.py
+++ b/deepomatic/api/client.py
@@ -23,10 +23,11 @@ THE SOFTWARE.
 """
 
 from deepomatic.api.http_helper import HTTPHelper
-from deepomatic.api.resources.network import Network
-from deepomatic.api.resources.recognition import RecognitionSpec, RecognitionVersion
-from deepomatic.api.resources.task import Task
 from deepomatic.api.resources.account import Account
+from deepomatic.api.resources.network import Network
+from deepomatic.api.resources.recognition import (RecognitionSpec,
+                                                  RecognitionVersion)
+from deepomatic.api.resources.task import Task
 
 
 class Client(object):
@@ -60,17 +61,8 @@ class Client(object):
            :param pool_maxsize (optional): Set `requests.adapters.HTTPAdapter.pool_maxsize` for concurrent calls.
                Defaults to 20.
            :type pool_maxsize: int
-           :param retry_if (optional): predicate to retry on requests errors.
-               More details directly in tenacity source code:
-                   - https://github.com/jd/tenacity/blob/1d05520276766d8c53fbb35b2b8368cc43a6c52c/tenacity/__init__.py#L179
-                   - https://github.com/jd/tenacity/blob/1d05520276766d8c53fbb35b2b8368cc43a6c52c/tenacity/retry.py
-           :type retry_if: tenacity.retry_base
-           :param retry_kwargs (optional): dict of retry parameters:
-               - timeout (default=60): raise tenacity.RetryError when timeout is reached (in seconds).
-                     If None, retry indefinitely.
-               - wait_exp_multiplier (default=0.05): wait exponential multiplier
-                -wait_exp_max (default=1.0): wait exponential maximum (in seconds)
-           :type retry_kwargs: dict
+           :param http_retryer (optional): Customize the retry of http errors
+           :type http_retryer: http_retryer.HTTPRetryer
 
            :return: :class:`Client` object
            :rtype: deepomatic.api.client.Client

--- a/deepomatic/api/client.py
+++ b/deepomatic/api/client.py
@@ -61,8 +61,8 @@ class Client(object):
            :param pool_maxsize (optional): Set `requests.adapters.HTTPAdapter.pool_maxsize` for concurrent calls.
                Defaults to 20.
            :type pool_maxsize: int
-           :param http_retryer (optional): Customize the retry of http errors
-           :type http_retryer: http_retryer.HTTPRetryer
+           :param http_retry (optional): Customize the retry of http errors
+           :type http_retry: http_retry.HTTPRetry
 
            :return: :class:`Client` object
            :rtype: deepomatic.api.client.Client

--- a/deepomatic/api/client.py
+++ b/deepomatic/api/client.py
@@ -61,7 +61,11 @@ class Client(object):
            :param pool_maxsize (optional): Set `requests.adapters.HTTPAdapter.pool_maxsize` for concurrent calls.
                Defaults to 20.
            :type pool_maxsize: int
-           :param http_retry (optional): Customize the retry of http errors
+           :param requests_timeout: timeout of each request.
+               Defaults to http_helper.RequestsTimeout.FAST.
+               More details in the `requests` documentation: https://2.python-requests.org//en/master/user/advanced/#timeouts
+           :type requests_timeout: float or tuple(float, float)
+           :param http_retry (optional): Customize the retry of http errors.
            :type http_retry: http_retry.HTTPRetry
 
            :return: :class:`Client` object

--- a/deepomatic/api/client.py
+++ b/deepomatic/api/client.py
@@ -44,7 +44,7 @@ class Client(object):
                If it fails raise a `DeepomaticException`.
            :type api_key: string
            :param verify_ssl (optional): whether to ask `requests` to verify the TLS/SSL certificates.
-               Defaults to `None`. 
+               Defaults to `None`.
                If `None` try to get it from the `DEEPOMATIC_API_VERIFY_TLS` environment variable (`0`: False, `1`: True).
                If not found it is set to True.
            :type verify_ssl: bool
@@ -60,6 +60,11 @@ class Client(object):
            :param pool_maxsize (optional): Set `requests.adapters.HTTPAdapter.pool_maxsize` for concurrent calls.
                Defaults to 20.
            :type pool_maxsize: int
+           :param retry_if (optional): predicate to retry on requests errors.
+               More details directly in tenacity source code:
+                   - https://github.com/jd/tenacity/blob/1d05520276766d8c53fbb35b2b8368cc43a6c52c/tenacity/__init__.py#L179
+                   - https://github.com/jd/tenacity/blob/1d05520276766d8c53fbb35b2b8368cc43a6c52c/tenacity/retry.py
+           :type retry_if: tenacity.retry_base
 
            :return: :class:`Client` object
            :rtype: deepomatic.api.client.Client

--- a/deepomatic/api/client.py
+++ b/deepomatic/api/client.py
@@ -65,6 +65,12 @@ class Client(object):
                    - https://github.com/jd/tenacity/blob/1d05520276766d8c53fbb35b2b8368cc43a6c52c/tenacity/__init__.py#L179
                    - https://github.com/jd/tenacity/blob/1d05520276766d8c53fbb35b2b8368cc43a6c52c/tenacity/retry.py
            :type retry_if: tenacity.retry_base
+           :param retry_kwargs (optional): dict of retry parameters:
+               - timeout (default=60): raise tenacity.RetryError when timeout is reached (in seconds).
+                     If None, retry indefinitely.
+               - wait_exp_multiplier (default=0.05): wait exponential multiplier
+                -wait_exp_max (default=1.0): wait exponential maximum (in seconds)
+           :type retry_kwargs: dict
 
            :return: :class:`Client` object
            :rtype: deepomatic.api.client.Client

--- a/deepomatic/api/client.py
+++ b/deepomatic/api/client.py
@@ -63,7 +63,7 @@ class Client(object):
            :type pool_maxsize: int
            :param requests_timeout: timeout of each request.
                Defaults to `http_helper.RequestsTimeout.FAST`.
-               More details in the `requests` documentation: https://2.python-requests.org//en/master/user/advanced/#timeouts
+               More details in the `requests` documentation: https://2.python-requests.org/en/master/user/advanced/#timeouts
            :type requests_timeout: float or tuple(float, float)
            :param http_retry (optional): Customize the retry of http errors.
                Defaults to `HTTPRetry()`. Check out `http_retry.HTTPRetry` documentation for more information about the parameters and default values.

--- a/deepomatic/api/client.py
+++ b/deepomatic/api/client.py
@@ -62,10 +62,12 @@ class Client(object):
                Defaults to 20.
            :type pool_maxsize: int
            :param requests_timeout: timeout of each request.
-               Defaults to http_helper.RequestsTimeout.FAST.
+               Defaults to `http_helper.RequestsTimeout.FAST`.
                More details in the `requests` documentation: https://2.python-requests.org//en/master/user/advanced/#timeouts
            :type requests_timeout: float or tuple(float, float)
            :param http_retry (optional): Customize the retry of http errors.
+               Defaults to `HTTPRetry()`. Check out `http_retry.HTTPRetry` documentation for more information about the parameters and default values.
+               If None, no retry will be done on errors.
            :type http_retry: http_retry.HTTPRetry
 
            :return: :class:`Client` object

--- a/deepomatic/api/exceptions.py
+++ b/deepomatic/api/exceptions.py
@@ -29,9 +29,8 @@ from tenacity import RetryError
 ###############################################################################
 
 class DeepomaticException(Exception):
-    pass
-    # def __init__(self, msg):
-    #     super(DeepomaticException, self).__init__(msg)
+    def __init__(self, msg):
+        super(DeepomaticException, self).__init__(msg)
 
 
 ###############################################################################

--- a/deepomatic/api/exceptions.py
+++ b/deepomatic/api/exceptions.py
@@ -23,13 +23,15 @@ THE SOFTWARE.
 """
 
 import json
+from tenacity import RetryError
 
 
 ###############################################################################
 
 class DeepomaticException(Exception):
-    def __init__(self, msg):
-        super(DeepomaticException, self).__init__(msg)
+    pass
+    # def __init__(self, msg):
+    #     super(DeepomaticException, self).__init__(msg)
 
 
 ###############################################################################
@@ -83,11 +85,23 @@ class TaskError(DeepomaticException):
 ###############################################################################
 
 class TaskTimeout(DeepomaticException):
-    def __init__(self, task):
+    def __init__(self, task, retry_error=None):
         self.task = task
+        self.retry_error = retry_error
 
     def __str__(self):
         return "Timeout on task:\n{}".format(json.dumps(self.task))
 
     def get_task_id(self):
         return self.task['id']
+
+
+###############################################################################
+
+
+class HTTPRetryError(RetryError):
+    pass
+
+
+class TaskRetryError(RetryError):
+    pass

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -53,8 +53,17 @@ class HTTPHelper(object):
                  user_agent_prefix='', user_agent_suffix='', pool_maxsize=20,
                  requests_timeout=RequestsTimeout.FAST, **kwargs):
         """
-        Init the HTTP helper with API key and secret
+        Init the HTTP helper with API key and secret.
+        Check out `client.Client` documentation for more details about the parameters.
         """
+
+        try:
+            self.http_retry = kwargs.pop('http_retry')
+        except KeyError:
+            self.http_retry = HTTPRetry()
+
+        self.requests_timeout = requests_timeout
+
         if host is None:
             host = os.getenv('DEEPOMATIC_API_URL', API_HOST)
         if verify_ssl is None:
@@ -65,13 +74,6 @@ class HTTPHelper(object):
             api_key = os.getenv('DEEPOMATIC_API_KEY')
         if app_id is None or api_key is None:
             raise DeepomaticException("Please specify 'app_id' and 'api_key' either by passing those values to the client or by defining the DEEPOMATIC_APP_ID and DEEPOMATIC_API_KEY environment variables.")
-
-        try:
-            self.http_retry = kwargs.pop('http_retry')
-        except KeyError:
-            self.http_retry = HTTPRetry()
-
-        self.requests_timeout = requests_timeout
 
         if not isinstance(version, string_types):
             version = 'v%g' % version

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -54,7 +54,7 @@ class HTTPHelper(object):
                  requests_timeout=RequestsTimeout.FAST, **kwargs):
         """
         Init the HTTP helper with API key and secret.
-        Check out `client.Client` documentation for more details about the parameters.
+        Check out the `client.Client` documentation for more details about the parameters.
         """
 
         try:

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -50,7 +50,7 @@ class HTTPHelper(object):
     def __init__(self, app_id=None, api_key=None, verify_ssl=None,
                  host=None, version=API_VERSION, check_query_parameters=True,
                  user_agent_prefix='', user_agent_suffix='', pool_maxsize=20,
-                 retry_if=None):
+                 retry_if=None, retry_kwargs=None):
         """
         Init the HTTP helper with API key and secret
         """
@@ -67,6 +67,7 @@ class HTTPHelper(object):
 
         self.retry_status_code = {}
         self.retry_if = retry_if
+        self.retry_kwargs = retry_kwargs or {}
 
         if self.retry_if is None:
             self.retry_status_code = set(DEFAULT_RETRY_STATUS_CODES)
@@ -232,7 +233,7 @@ class HTTPHelper(object):
         functor = Functor(func, resource, *args, params=params,
                           data=data, files=files, headers=headers,
                           verify=self.verify, stream=stream, **kwargs)
-        response = retry(functor, self.retry_if)
+        response = retry(functor, self.retry_if, **self.retry_kwargs)
 
         # Close opened files
         for file in opened_files:

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -51,7 +51,7 @@ class HTTPHelper(object):
     def __init__(self, app_id=None, api_key=None, verify_ssl=None,
                  host=None, version=API_VERSION, check_query_parameters=True,
                  user_agent_prefix='', user_agent_suffix='', pool_maxsize=20,
-                 requests_timeout=RequestsTimeout.FAST, http_retry=None):
+                 requests_timeout=RequestsTimeout.FAST, http_retry=HTTPRetry()):
         """
         Init the HTTP helper with API key and secret
         """
@@ -66,7 +66,11 @@ class HTTPHelper(object):
         if app_id is None or api_key is None:
             raise DeepomaticException("Please specify 'app_id' and 'api_key' either by passing those values to the client or by defining the DEEPOMATIC_APP_ID and DEEPOMATIC_API_KEY environment variables.")
 
-        self.http_retry = http_retry or HTTPRetry()
+        # WARNING for developers: `self.http_retry` should not be modified in this class.
+        # It should be a constant object.
+        # This will affect the default parameter otherwise.
+        self.http_retry = http_retry
+
         self.requests_timeout = requests_timeout
 
         if not isinstance(version, string_types):

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -66,7 +66,7 @@ class HTTPHelper(object):
         if app_id is None or api_key is None:
             raise DeepomaticException("Please specify 'app_id' and 'api_key' either by passing those values to the client or by defining the DEEPOMATIC_APP_ID and DEEPOMATIC_API_KEY environment variables.")
 
-        self.http_retry = http_retry or HTTPRetry.DEFAULT
+        self.http_retry = http_retry or HTTPRetry()
         self.requests_timeout = requests_timeout
 
         if not isinstance(version, string_types):

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -57,10 +57,10 @@ class HTTPHelper(object):
         Check out the `client.Client` documentation for more details about the parameters.
         """
 
-        try:
-            self.http_retry = kwargs.pop('http_retry')
-        except KeyError:
-            self.http_retry = HTTPRetry()
+        self.http_retry = kwargs.pop('http_retry', HTTPRetry())
+
+        if len(kwargs) > 0:
+            raise TypeError("Too many parameters. HTTPRetry does not handle kwargs: {}".format(kwargs))
 
         self.requests_timeout = requests_timeout
 
@@ -179,16 +179,10 @@ class HTTPHelper(object):
 
     def send_request(self, requests_callable, *args, **kwargs):
         # requests_callable must be a method from the requests module
-        try:
-            # this is the timeout of requests module
-            requests_timeout = kwargs.pop('timeout')
-        except KeyError:
-            requests_timeout = self.requests_timeout
 
-        try:
-            http_retry = kwargs.pop('http_retry')
-        except KeyError:
-            http_retry = self.http_retry
+        # this is the timeout of requests module
+        requests_timeout = kwargs.pop('timeout', self.requests_timeout)
+        http_retry = kwargs.pop('http_retry', self.http_retry)
 
         functor = functools.partial(requests_callable, *args,
                                     verify=self.verify,

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -51,7 +51,7 @@ class HTTPHelper(object):
     def __init__(self, app_id=None, api_key=None, verify_ssl=None,
                  host=None, version=API_VERSION, check_query_parameters=True,
                  user_agent_prefix='', user_agent_suffix='', pool_maxsize=20,
-                 requests_timeout=RequestsTimeout.FAST, http_retry=HTTPRetry()):
+                 requests_timeout=RequestsTimeout.FAST, **kwargs):
         """
         Init the HTTP helper with API key and secret
         """
@@ -66,10 +66,10 @@ class HTTPHelper(object):
         if app_id is None or api_key is None:
             raise DeepomaticException("Please specify 'app_id' and 'api_key' either by passing those values to the client or by defining the DEEPOMATIC_APP_ID and DEEPOMATIC_API_KEY environment variables.")
 
-        # WARNING for developers: `self.http_retry` should not be modified in this class.
-        # It should be a constant object.
-        # This will affect the default parameter otherwise.
-        self.http_retry = http_retry
+        try:
+            self.http_retry = kwargs.pop('http_retry')
+        except KeyError:
+            self.http_retry = HTTPRetry()
 
         self.requests_timeout = requests_timeout
 

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -22,20 +22,20 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import os
+import functools
 import json
-import requests
-from requests.exceptions import RequestException
-import sys
+import os
 import platform
+import sys
+
+import requests
+from deepomatic.api.exceptions import BadStatus, DeepomaticException
+from deepomatic.api.utils import retry
+from deepomatic.api.version import __title__, __version__
+from requests.exceptions import RequestException
 from requests.structures import CaseInsensitiveDict
 from six import string_types
-
-from tenacity import retry_if_result, retry_if_exception_type
-
-from deepomatic.api.utils import Functor, retry
-from deepomatic.api.exceptions import DeepomaticException, BadStatus
-from deepomatic.api.version import __title__, __version__
+from tenacity import retry_if_exception_type, retry_if_result
 
 API_HOST = 'https://api.deepomatic.com'
 API_VERSION = 0.7
@@ -230,9 +230,9 @@ class HTTPHelper(object):
         if not resource.startswith('http'):
             resource = self.resource_prefix + resource
 
-        functor = Functor(func, resource, *args, params=params,
-                          data=data, files=files, headers=headers,
-                          verify=self.verify, stream=stream, **kwargs)
+        functor = functools.partial(func, resource, *args, params=params,
+                                    data=data, files=files, headers=headers,
+                                    verify=self.verify, stream=stream, **kwargs)
         response = retry(functor, self.retry_if, **self.retry_kwargs)
 
         # Close opened files

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -57,6 +57,8 @@ class HTTPHelper(object):
         Check out the `client.Client` documentation for more details about the parameters.
         """
 
+        # `http_retry` is retrieved from `kwargs` because a default parameter `http_retry=HTTPRetry()` is dangerous
+        # If the rest of the code mutates `self.http_retry`, it would change the default parameter for all other `Client` instances
         self.http_retry = kwargs.pop('http_retry', HTTPRetry())
 
         if len(kwargs) > 0:

--- a/deepomatic/api/http_retry.py
+++ b/deepomatic/api/http_retry.py
@@ -6,13 +6,6 @@ from requests.exceptions import (ProxyError, RequestException,
 from tenacity import (retry_if_exception, retry_if_result, stop_after_delay,
                       wait_chain, wait_fixed, wait_random_exponential)
 
-DEFAULT_REQUESTS_TIMEOUT = (3.05, 10)
-DEFAULT_RETRY_EXP_MAX = 10.
-DEFAULT_RETRY_EXP_MULTIPLIER = 0.5
-DEFAULT_RETRY_STATUS_CODES = [502, 503, 504]
-DEFAULT_RETRY_EXCEPTION_TYPES = (RequestException, )
-DEFAULT_RETRY_EXCEPTION_TYPES_BLACKLIST = (ValueError, ProxyError, TooManyRedirects, URLRequired)
-
 
 class retry_if_exception_type(retry_if_exception):
     def __predicate(self, e):
@@ -26,23 +19,30 @@ class retry_if_exception_type(retry_if_exception):
         super(retry_if_exception_type, self).__init__(self.__predicate)
 
 
-class HTTPRetryer(object):
+class RequestsTimeout(object):
+    FAST = (3.05, 10.)
+    MEDIUM = (3.05, 60.)
+    SLOW = (3.05, 600.)
+
+
+class HTTPRetry(object):
+
     """
            :param retry_if (optional): predicate to retry on requests errors.
                More details directly in tenacity source code:
                    - https://github.com/jd/tenacity/blob/1d05520276766d8c53fbb35b2b8368cc43a6c52c/tenacity/__init__.py#L179
                    - https://github.com/jd/tenacity/blob/1d05520276766d8c53fbb35b2b8368cc43a6c52c/tenacity/retry.py
                If not provided, the default behavior is:
-                   - Retry on status code from DEFAULT_RETRY_STATUS_CODES
-                   - Retry on exceptions from DEFAULT_RETRY_EXCEPTION_TYPES excluding those from DEFAULT_RETRY_EXCEPTION_TYPES_BLACKLIST
+                   - Retry on status code from Default.RETRY_STATUS_CODES
+                   - Retry on exceptions from Default.RETRY_EXCEPTION_TYPES excluding those from Default.RETRY_EXCEPTION_TYPES_BLACKLIST
            :type retry_if: tenacity.retry_base
            :param wait (optional): how to wait between retry
                More details directly in tenacity source code https://github.com/jd/tenacity/blob/1d05520276766d8c53fbb35b2b8368cc43a6c52c/tenacity/wait.py
 
                if not provided, the default behavior is:
                ```
-                   random_wait = wait_random_exponential(multiplier=DEFAULT_RETRY_EXP_MULTIPLIER,
-                                                         max=DEFAULT_RETRY_EXP_MAX)
+                   random_wait = wait_random_exponential(multiplier=Default.RETRY_EXP_MULTIPLIER,
+                                                         max=Default.RETRY_EXP_MAX)
                    wait_chain(wait_fixed(0.05),
                               wait_fixed(0.1),
                               wait_fixed(0.1) + random_wait)
@@ -55,37 +55,53 @@ class HTTPRetryer(object):
             :param requests_timeout: float or tuple(float, float)
 
     """
+
+    class Default(object):
+        RETRY_EXP_MAX = 10.
+        RETRY_EXP_MULTIPLIER = 0.5
+        RETRY_STATUS_CODES = [500, 502, 503, 504]
+        RETRY_EXCEPTION_TYPES = (RequestException, )
+        RETRY_EXCEPTION_TYPES_BLACKLIST = (ValueError, ProxyError, TooManyRedirects, URLRequired)
+
+
     def __init__(self, retry_if=None, wait=None, stop=None,
-                 requests_timeout=DEFAULT_REQUESTS_TIMEOUT):
+                 requests_timeout=RequestsTimeout.FAST):
         self.retry_status_code = {}
         self.retry_if = retry_if
         self.requests_timeout = requests_timeout
         self.wait = wait
         self.stop = stop
+
         if self.stop is None:
             self.stop = stop_after_delay(60)
 
         if self.retry_if is None:
-            self.retry_status_code = set(DEFAULT_RETRY_STATUS_CODES)
+            self.retry_status_code = set(HTTPRetry.Default.RETRY_STATUS_CODES)
             self.retry_if = (retry_if_result(self.retry_if_status_code) |
-                             retry_if_exception_type(DEFAULT_RETRY_EXCEPTION_TYPES,
-                                                     DEFAULT_RETRY_EXCEPTION_TYPES_BLACKLIST))
+                             retry_if_exception_type(HTTPRetry.Default.RETRY_EXCEPTION_TYPES,
+                                                     HTTPRetry.Default.RETRY_EXCEPTION_TYPES_BLACKLIST))
+
         if self.wait is None:
-            random_wait = wait_random_exponential(multiplier=DEFAULT_RETRY_EXP_MULTIPLIER,
-                                                  max=DEFAULT_RETRY_EXP_MAX)
+            random_wait = wait_random_exponential(multiplier=HTTPRetry.Default.RETRY_EXP_MULTIPLIER,
+                                                  max=HTTPRetry.Default.RETRY_EXP_MAX)
             self.wait = wait_chain(wait_fixed(0.05),
                                    wait_fixed(0.1),
                                    wait_fixed(0.1) + random_wait)
 
-
-    def retry_if_status_code(self, response):
-        return response.status_code in self.retry_status_code
-
-    def retry(self, *args, **kwargs):
+    def retry(self, requests_callable, *args, **kwargs):
         try:
+            # this is the timeout of requests module
+            # not the one of the retry
             requests_timeout = kwargs.pop('timeout')
         except KeyError:
             requests_timeout = self.requests_timeout
 
-        functor = functools.partial(*args, timeout=requests_timeout, **kwargs)
+        functor = functools.partial(requests_callable, *args,
+                                    timeout=requests_timeout, **kwargs)
         return retry(functor, self.retry_if, self.wait, self.stop)
+
+    def retry_if_status_code(self, response):
+        return response.status_code in self.retry_status_code
+
+
+HTTPRetry.DEFAULT = HTTPRetry()

--- a/deepomatic/api/http_retry.py
+++ b/deepomatic/api/http_retry.py
@@ -1,6 +1,6 @@
 import functools
 
-from deepomatic.api.utils import retry
+from deepomatic.api import utils
 from requests.exceptions import (ProxyError, RequestException,
                                  TooManyRedirects, URLRequired)
 from tenacity import (retry_if_exception, retry_if_result, stop_after_delay,
@@ -80,10 +80,7 @@ class HTTPRetry(object):
                                    wait_fixed(0.1) + random_wait)
 
     def retry(self, functor):
-        return retry(functor, self.retry_if, self.wait, self.stop)
+        return utils.retry(functor, self.retry_if, self.wait, self.stop)
 
     def retry_if_status_code(self, response):
         return response.status_code in self.retry_status_code
-
-
-HTTPRetry.DEFAULT = HTTPRetry()

--- a/deepomatic/api/http_retry.py
+++ b/deepomatic/api/http_retry.py
@@ -1,6 +1,7 @@
 import functools
 
 from deepomatic.api import utils
+from deepomatic.api.exceptions import HTTPRetryError
 from requests.exceptions import (ProxyError, RequestException,
                                  TooManyRedirects, URLRequired)
 from tenacity import (retry_if_exception, retry_if_result, stop_after_delay,
@@ -80,7 +81,7 @@ class HTTPRetry(object):
                                    wait_fixed(0.1) + random_wait)
 
     def retry(self, functor):
-        return utils.retry(functor, self.retry_if, self.wait, self.stop)
+        return utils.retry(functor, self.retry_if, self.wait, self.stop, retry_error_cls=HTTPRetryError)
 
     def retry_if_status_code(self, response):
         return response.status_code in self.retry_status_code

--- a/deepomatic/api/http_retry.py
+++ b/deepomatic/api/http_retry.py
@@ -21,12 +21,6 @@ class retry_if_exception_type(retry_if_exception):
         super(retry_if_exception_type, self).__init__(self.__predicate)
 
 
-class RequestsTimeout(object):
-    FAST = (3.05, 10.)
-    MEDIUM = (3.05, 60.)
-    SLOW = (3.05, 600.)
-
-
 class HTTPRetry(object):
 
     """
@@ -54,9 +48,6 @@ class HTTPRetry(object):
             :param stop (optional). Tell when to stop retrying. By default it stops retrying after a delay of 60 seconds. A last retry can be done just before this delay is reached, thus the total amount of elapsed time might be a bit higher. More details in tenacity source code https://github.com/jd/tenacity/blob/5.1.1/tenacity/stop.py
                 Raises tenacity.RetryError when timeout is reached.
             :type timeout: tenacity.stop_base
-            :param requests_timeout: timeout of each request. More details in the `requests` documentation: https://2.python-requests.org//en/master/user/advanced/#timeouts
-            :type requests_timeout: float or tuple(float, float)
-
     """
 
     class Default(object):
@@ -66,11 +57,9 @@ class HTTPRetry(object):
         RETRY_EXCEPTION_TYPES = (RequestException, )
         RETRY_EXCEPTION_TYPES_BLACKLIST = (ValueError, ProxyError, TooManyRedirects, URLRequired)
 
-    def __init__(self, retry_if=None, wait=None, stop=None,
-                 requests_timeout=RequestsTimeout.FAST):
+    def __init__(self, retry_if=None, wait=None, stop=None):
         self.retry_status_code = {}
         self.retry_if = retry_if
-        self.requests_timeout = requests_timeout
         self.wait = wait
         self.stop = stop
 
@@ -90,17 +79,7 @@ class HTTPRetry(object):
                                    wait_fixed(0.1),
                                    wait_fixed(0.1) + random_wait)
 
-    def retry(self, requests_callable, *args, **kwargs):
-        try:
-            # requests_callable must be a method from the requests module
-            # this is the timeout of requests module
-            # not the one of the retry
-            requests_timeout = kwargs.pop('timeout')
-        except KeyError:
-            requests_timeout = self.requests_timeout
-
-        functor = functools.partial(requests_callable, *args,
-                                    timeout=requests_timeout, **kwargs)
+    def retry(self, functor):
         return retry(functor, self.retry_if, self.wait, self.stop)
 
     def retry_if_status_code(self, response):

--- a/deepomatic/api/http_retryer.py
+++ b/deepomatic/api/http_retryer.py
@@ -1,0 +1,91 @@
+import functools
+
+from deepomatic.api.utils import retry
+from requests.exceptions import (ProxyError, RequestException,
+                                 TooManyRedirects, URLRequired)
+from tenacity import (retry_if_exception, retry_if_result, stop_after_delay,
+                      wait_chain, wait_fixed, wait_random_exponential)
+
+DEFAULT_REQUESTS_TIMEOUT = (3.05, 10)
+DEFAULT_RETRY_EXP_MAX = 10.
+DEFAULT_RETRY_EXP_MULTIPLIER = 0.5
+DEFAULT_RETRY_STATUS_CODES = [502, 503, 504]
+DEFAULT_RETRY_EXCEPTION_TYPES = (RequestException, )
+DEFAULT_RETRY_EXCEPTION_TYPES_BLACKLIST = (ValueError, ProxyError, TooManyRedirects, URLRequired)
+
+
+class retry_if_exception_type(retry_if_exception):
+    def __predicate(self, e):
+        return (isinstance(e, self.exception_types) and
+                not isinstance(e, self.exception_types_blacklist))
+
+    def __init__(self, exception_types=Exception,
+                 exception_types_blacklist=()):
+        self.exception_types = exception_types
+        self.exception_types_blacklist = exception_types_blacklist
+        super(retry_if_exception_type, self).__init__(self.__predicate)
+
+
+class HTTPRetryer(object):
+    """
+           :param retry_if (optional): predicate to retry on requests errors.
+               More details directly in tenacity source code:
+                   - https://github.com/jd/tenacity/blob/1d05520276766d8c53fbb35b2b8368cc43a6c52c/tenacity/__init__.py#L179
+                   - https://github.com/jd/tenacity/blob/1d05520276766d8c53fbb35b2b8368cc43a6c52c/tenacity/retry.py
+               If not provided, the default behavior is:
+                   - Retry on status code from DEFAULT_RETRY_STATUS_CODES
+                   - Retry on exceptions from DEFAULT_RETRY_EXCEPTION_TYPES excluding those from DEFAULT_RETRY_EXCEPTION_TYPES_BLACKLIST
+           :type retry_if: tenacity.retry_base
+           :param wait (optional): how to wait between retry
+               More details directly in tenacity source code https://github.com/jd/tenacity/blob/1d05520276766d8c53fbb35b2b8368cc43a6c52c/tenacity/wait.py
+
+               if not provided, the default behavior is:
+               ```
+                   random_wait = wait_random_exponential(multiplier=DEFAULT_RETRY_EXP_MULTIPLIER,
+                                                         max=DEFAULT_RETRY_EXP_MAX)
+                   wait_chain(wait_fixed(0.05),
+                              wait_fixed(0.1),
+                              wait_fixed(0.1) + random_wait)
+               ```
+            :type wait: tenacity.wait_base
+            :param stop (optional). Tell when to stop retrying. By default it stops retrying after a delay of 60 seconds. A last retry can be done just before this delay is reached, thus the total amount of elapsed time might be a bit higher. More details in tenacity source code https://github.com/jd/tenacity/blob/1d05520276766d8c53fbb35b2b8368cc43a6c52c/tenacity/stop.py
+                Raises tenacity.RetryError when timeout is reached.
+            :type timeout: tenacity.stop_base
+            :param requests_timeout: timeout of each request. More details in the `requests` documentation: https://2.python-requests.org//en/master/user/advanced/#timeouts
+            :param requests_timeout: float or tuple(float, float)
+
+    """
+    def __init__(self, retry_if=None, wait=None, stop=None,
+                 requests_timeout=DEFAULT_REQUESTS_TIMEOUT):
+        self.retry_status_code = {}
+        self.retry_if = retry_if
+        self.requests_timeout = requests_timeout
+        self.wait = wait
+        self.stop = stop
+        if self.stop is None:
+            self.stop = stop_after_delay(60)
+
+        if self.retry_if is None:
+            self.retry_status_code = set(DEFAULT_RETRY_STATUS_CODES)
+            self.retry_if = (retry_if_result(self.retry_if_status_code) |
+                             retry_if_exception_type(DEFAULT_RETRY_EXCEPTION_TYPES,
+                                                     DEFAULT_RETRY_EXCEPTION_TYPES_BLACKLIST))
+        if self.wait is None:
+            random_wait = wait_random_exponential(multiplier=DEFAULT_RETRY_EXP_MULTIPLIER,
+                                                  max=DEFAULT_RETRY_EXP_MAX)
+            self.wait = wait_chain(wait_fixed(0.05),
+                                   wait_fixed(0.1),
+                                   wait_fixed(0.1) + random_wait)
+
+
+    def retry_if_status_code(self, response):
+        return response.status_code in self.retry_status_code
+
+    def retry(self, *args, **kwargs):
+        try:
+            requests_timeout = kwargs.pop('timeout')
+        except KeyError:
+            requests_timeout = self.requests_timeout
+
+        functor = functools.partial(*args, timeout=requests_timeout, **kwargs)
+        return retry(functor, self.retry_if, self.wait, self.stop)

--- a/deepomatic/api/inference.py
+++ b/deepomatic/api/inference.py
@@ -1,0 +1,23 @@
+from deepomatic.api.exceptions import DeepomaticException
+from deepomatic.api.resources.task import Task
+from deepomatic.api.inputs import format_inputs
+
+
+class InferenceResource(object):
+    def inference(self, return_task=False, wait_task=True, **kwargs):
+        assert(self._pk is not None)
+
+        inputs = kwargs.pop('inputs', None)
+        if inputs is None:
+            raise DeepomaticException("Missing keyword argument: inputs")
+        content_type, data, files = format_inputs(inputs, kwargs)
+        result = self._helper.post(self._uri(pk=self._pk, suffix='/inference'), content_type=content_type, data=data, files=files)
+        task_id = result['task_id']
+        task = Task(self._helper, pk=task_id)
+        if wait_task:
+            task.wait()
+
+        if return_task:
+            return task
+        else:
+            return task['data']

--- a/deepomatic/api/mixins.py
+++ b/deepomatic/api/mixins.py
@@ -25,7 +25,6 @@ THE SOFTWARE.
 from deepomatic.api.exceptions import DeepomaticException
 from deepomatic.api.resource import ResourceList
 
-
 ###############################################################################
 
 class Arg(object):
@@ -85,7 +84,7 @@ class DeletableResource(object):
 ###############################################################################
 
 class CreateableResource(object):
-    def create(self, content_type='application/json', files=None, **kwargs):
+    def create(self, content_type='application/json', files=None, http_retryer=None, **kwargs):
         if self._helper.check_query_parameters:
             for arg_name in kwargs:
                 if arg_name not in self.object_template or self.object_template[arg_name]._shoud_be_present_when_adding is False:
@@ -96,7 +95,8 @@ class CreateableResource(object):
 
         if files is not None:
             content_type = 'multipart/mixed'
-        data = self._helper.post(self._uri(), data=kwargs, content_type=content_type, files=files)
+        data = self._helper.post(self._uri(), data=kwargs, content_type=content_type,
+                                 files=files, http_retryer=http_retryer)
         return self.__class__(self._helper, pk=data['id'], data=data)
 
 
@@ -108,5 +108,3 @@ class ListableResource(object):
 
 
 ###############################################################################
-
-

--- a/deepomatic/api/mixins.py
+++ b/deepomatic/api/mixins.py
@@ -25,6 +25,7 @@ THE SOFTWARE.
 from deepomatic.api.exceptions import DeepomaticException
 from deepomatic.api.resource import ResourceList
 
+
 ###############################################################################
 
 class Arg(object):

--- a/deepomatic/api/resources/network.py
+++ b/deepomatic/api/resources/network.py
@@ -23,7 +23,7 @@ THE SOFTWARE.
 """
 
 import numpy as np
-from deepomatic.api.http_retry import HTTPRetry, RequestsTimeout
+from deepomatic.api.http_helper import RequestsTimeout
 from deepomatic.api.inference import InferenceResource
 from deepomatic.api.mixins import (CreateableResource, DeletableResource,
                                    ImmutableArg, ListableResource,
@@ -31,11 +31,8 @@ from deepomatic.api.mixins import (CreateableResource, DeletableResource,
                                    UpdatableResource)
 from deepomatic.api.resource import Resource
 from six import string_types
-from tenacity import stop_after_attempt
 
 ###############################################################################
-
-
 
 
 class Network(ListableResource,

--- a/deepomatic/api/resources/network.py
+++ b/deepomatic/api/resources/network.py
@@ -23,7 +23,7 @@ THE SOFTWARE.
 """
 
 import numpy as np
-from deepomatic.api.http_retryer import HTTPRetryer
+from deepomatic.api.http_retry import HTTPRetry, RequestsTimeout
 from deepomatic.api.inference import InferenceResource
 from deepomatic.api.mixins import (CreateableResource, DeletableResource,
                                    ImmutableArg, ListableResource,
@@ -35,9 +35,7 @@ from tenacity import stop_after_attempt
 
 ###############################################################################
 
-# No retry on network create as this is an heavy request
-NETWORK_CREATE_RETRYER = HTTPRetryer(requests_timeout=(3.05, 600),
-                                     stop=stop_after_attempt(0))
+
 
 
 class Network(ListableResource,
@@ -74,7 +72,9 @@ class Network(ListableResource,
             return result
 
     def create(self, *args, **kwargs):
-        kwargs['http_retryer'] = kwargs.get('http_retryer', NETWORK_CREATE_RETRYER)
+        # No retry on network create by default as this is an heavy request
+        kwargs['http_retry'] = kwargs.get('http_retry')
+        kwargs['timeout'] = kwargs.get('timeout', RequestsTimeout.SLOW)
         return super(Network, self).create(*args, **kwargs)
 
     @staticmethod

--- a/deepomatic/api/resources/network.py
+++ b/deepomatic/api/resources/network.py
@@ -70,7 +70,7 @@ class Network(ListableResource,
 
     def create(self, *args, **kwargs):
         # No retry on network create by default as this is an heavy request
-        kwargs['http_retry'] = kwargs.get('http_retry')
+        kwargs['http_retry'] = kwargs.get('http_retry', None)
         kwargs['timeout'] = kwargs.get('timeout', RequestsTimeout.SLOW)
         return super(Network, self).create(*args, **kwargs)
 

--- a/deepomatic/api/resources/network.py
+++ b/deepomatic/api/resources/network.py
@@ -26,7 +26,7 @@ from six import string_types
 import numpy as np
 
 from deepomatic.api.resource import Resource
-from deepomatic.api.utils import InferenceResource
+from deepomatic.api.inference import InferenceResource
 from deepomatic.api.mixins import CreateableResource, ListableResource, UpdatableResource, DeletableResource
 from deepomatic.api.mixins import RequiredArg, OptionnalArg, ImmutableArg
 

--- a/deepomatic/api/resources/network.py
+++ b/deepomatic/api/resources/network.py
@@ -69,7 +69,7 @@ class Network(ListableResource,
             return result
 
     def create(self, *args, **kwargs):
-        # No retry on network create by default as this is an heavy request
+        # No retry on Network.create() errors by default as this is a large request
         kwargs['http_retry'] = kwargs.get('http_retry', None)
         kwargs['timeout'] = kwargs.get('timeout', RequestsTimeout.SLOW)
         return super(Network, self).create(*args, **kwargs)

--- a/deepomatic/api/resources/recognition.py
+++ b/deepomatic/api/resources/recognition.py
@@ -25,7 +25,7 @@ THE SOFTWARE.
 from six import string_types
 
 from deepomatic.api.resource import Resource, ResourceList
-from deepomatic.api.utils import InferenceResource
+from deepomatic.api.inference import InferenceResource
 from deepomatic.api.mixins import CreateableResource, ListableResource, UpdatableResource, DeletableResource
 from deepomatic.api.mixins import RequiredArg, OptionnalArg, ImmutableArg, UpdateOnlyArg
 
@@ -76,4 +76,3 @@ class RecognitionVersion(CreateableResource,
         'network_id':       RequiredArg(),
         'post_processings': RequiredArg(),
     }
-

--- a/deepomatic/api/resources/task.py
+++ b/deepomatic/api/resources/task.py
@@ -99,7 +99,7 @@ class Task(ListableResource, Resource):
     def _refresh_status(self):
         logger.debug("Refreshing Task {}".format(self))
         warn_on_http_retry_error(self.refresh, suffix="Retrying until Task.wait timeouts.", reraise=True)
-        return self['status']
+        return self._data['status']
 
     def _refresh_tasks_status(self, pending_tasks, success_tasks, error_tasks, positions):
         logger.debug("Refreshing batch of Task {}".format(pending_tasks))

--- a/deepomatic/api/resources/task.py
+++ b/deepomatic/api/resources/task.py
@@ -31,7 +31,7 @@ from deepomatic.api.mixins import ListableResource
 from deepomatic.api.resource import Resource
 from deepomatic.api.utils import retry, warn_on_http_retry_error
 from tenacity import (RetryError, retry_if_exception_type, retry_if_result,
-                      stop_after_delay, wait_chain, wait_fixed,
+                      stop_after_delay, wait_chain, wait_fixed, stop_never,
                       wait_random_exponential)
 
 logger = logging.getLogger(__name__)

--- a/deepomatic/api/utils.py
+++ b/deepomatic/api/utils.py
@@ -25,7 +25,7 @@ THE SOFTWARE.
 import logging
 from tenacity import (Retrying, wait_random_exponential,
                       stop_after_delay, retry_if_result,
-                      retry_if_exception_type,
+                      retry_if_exception_type, stop_never,
                       before_log, after_log)
 
 
@@ -44,9 +44,15 @@ class Functor(object):
 
 def retry(apply_func, retry,
           timeout=60, wait_exp_multiplier=0.05, wait_exp_max=1.0):
+
+    if timeout is None:
+        stop = stop_never
+    else:
+        stop = stop_after_delay(timeout)
+
     retryer = Retrying(wait=wait_random_exponential(multiplier=wait_exp_multiplier,
                                                     max=wait_exp_max),
-                       stop=stop_after_delay(timeout),
+                       stop=stop,
                        retry=retry,
                        before=before_log(logger, logging.DEBUG),
                        after=after_log(logger, logging.DEBUG))

--- a/deepomatic/api/utils.py
+++ b/deepomatic/api/utils.py
@@ -23,23 +23,11 @@ THE SOFTWARE.
 """
 
 import logging
-from tenacity import (Retrying, wait_random_exponential,
-                      stop_after_delay, retry_if_result,
-                      retry_if_exception_type, stop_never,
-                      before_log, after_log)
 
+from tenacity import (Retrying, after_log, before_log, stop_after_delay,
+                      stop_never, wait_random_exponential)
 
 logger = logging.getLogger(__name__)
-
-
-class Functor(object):
-    def __init__(self, func, *args, **kwargs):
-        self.func = func
-        self.args = args
-        self.kwargs = kwargs
-
-    def __call__(self):
-        return self.func(*self.args, **self.kwargs)
 
 
 def retry(apply_func, retry,

--- a/deepomatic/api/utils.py
+++ b/deepomatic/api/utils.py
@@ -25,8 +25,7 @@ THE SOFTWARE.
 import logging
 
 from deepomatic.api.exceptions import HTTPRetryError
-from tenacity import (RetryError, Retrying, after_log, before_log,
-                      stop_after_delay, stop_never, wait_random_exponential)
+from tenacity import (Retrying, after_log, before_log)
 
 logger = logging.getLogger(__name__)
 

--- a/deepomatic/api/utils.py
+++ b/deepomatic/api/utils.py
@@ -60,3 +60,4 @@ def warn_on_http_retry_error(http_func, suffix='', reraise=True):
         logger.warning(msg)
         if reraise:
             raise
+        return None

--- a/deepomatic/api/utils.py
+++ b/deepomatic/api/utils.py
@@ -27,37 +27,10 @@ from tenacity import (Retrying, wait_random_exponential,
                       stop_after_delay, retry_if_result,
                       retry_if_exception_type,
                       before_log, after_log)
-from deepomatic.api.exceptions import DeepomaticException
-from deepomatic.api.resources.task import Task
-from deepomatic.api.inputs import format_inputs
 
 
 logger = logging.getLogger(__name__)
 
-
-###############################################################################
-
-class InferenceResource(object):
-    def inference(self, return_task=False, wait_task=True, **kwargs):
-        assert(self._pk is not None)
-
-        inputs = kwargs.pop('inputs', None)
-        if inputs is None:
-            raise DeepomaticException("Missing keyword argument: inputs")
-        content_type, data, files = format_inputs(inputs, kwargs)
-        result = self._helper.post(self._uri(pk=self._pk, suffix='/inference'), content_type=content_type, data=data, files=files)
-        task_id = result['task_id']
-        task = Task(self._helper, pk=task_id)
-        if wait_task:
-            task.wait()
-
-        if return_task:
-            return task
-        else:
-            return task['data']
-
-
-###############################################################################
 
 class Functor(object):
     def __init__(self, func, *args, **kwargs):

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -4,4 +4,7 @@ set -e
 
 apt-get update && apt-get install -y build-essential
 pip install -r requirements.txt
-pip install pytest==4.0.2 pytest-cov==2.6.1 pytest-voluptuous==1.1.0 # for testing
+pip install pytest==4.0.2 \
+            pytest-cov==2.6.1 \
+            pytest-voluptuous==1.1.0 \
+            httpretty==0.9.6 # for testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy>=1.10.0,<2
 promise>=2.1,<3
 six>=1.10.0,<2
 requests>=2.19.0,<3  # will not work below in python3
-tenacity>=4.12.0,<5
+tenacity>=5.1,<6

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,11 @@ import os
 import io
 from setuptools import find_packages, setup
 
-try: # for pip >= 10
+try:
+    # for pip >= 10
     from pip._internal.req import parse_requirements
-except ImportError: # for pip <= 9.0.3
+except ImportError:
+    # for pip <= 9.0.3
     from pip.req import parse_requirements
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -296,4 +296,5 @@ def test_retry_client():
     with pytest.raises(RetryError) as e:
         print(spec.data())
 
-    assert time.time() - start_time > timeout
+    diff = time.time() - start_time
+    assert diff > timeout and diff < timeout + 5

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
 import base64
+import functools
 import hashlib
 import logging
 import os
@@ -349,16 +350,16 @@ class TestClientRetry(object):
         # Creating network doesn't retry, we directly get a 502
         t = time.time()
         with pytest.raises(BadStatus) as exc:
-            network = client.Network.create(name="My first network",
-                                            framework='tensorflow-1.x',
-                                            preprocessing=["useless"],
-                                            files=["useless"])
+            client.Network.create(name="My first network",
+                                  framework='tensorflow-1.x',
+                                  preprocessing=["useless"],
+                                  files=["useless"])
             assert 502 == exc.status_code
         assert time.time() - t < 0.3
 
     def test_no_retry_blacklist_exception(self):
-         http_retry = HTTPRetry(stop=stop_after_delay(self.DEFAULT_TIMEOUT))
-         client = Client(http_retry=http_retry)
-         # check that there is no retry on exceptions from DEFAULT_RETRY_EXCEPTION_TYPES_BLACKLIST
-         with pytest.raises(MissingSchema) as exc:
-             client.http_helper.http_retry.retry(requests.get, '')
+        http_retry = HTTPRetry(stop=stop_after_delay(self.DEFAULT_TIMEOUT))
+        client = Client(http_retry=http_retry)
+        # check that there is no retry on exceptions from DEFAULT_RETRY_EXCEPTION_TYPES_BLACKLIST
+        with pytest.raises(MissingSchema):
+            client.http_helper.http_retry.retry(functools.partial(requests.get, ''))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -312,7 +312,7 @@ class TestClientRetry(object):
         spec = client.RecognitionSpec.retrieve('imagenet-inception-v3')  # doesn't make any http call
         start_time = time.time()
         with pytest.raises(RetryError) as exc:
-            print(spec.data()) # does make a http call
+            print(spec.data())  # does make a http call
 
         diff = time.time() - start_time
         assert diff > timeout and diff < timeout + HTTPRetry.Default.RETRY_EXP_MAX
@@ -323,7 +323,7 @@ class TestClientRetry(object):
     def test_retry_network_failure(self):
         http_retry = HTTPRetry(stop=stop_after_delay(self.DEFAULT_TIMEOUT))
         client = get_client(host='http://unknown-domain.com',
-                        http_retry=http_retry)
+                            http_retry=http_retry)
         last_attempt = self.send_request_and_expect_retry(client, self.DEFAULT_TIMEOUT,
                                                           self.DEFAULT_MIN_ATTEMPT_NUMBER)
         exc = last_attempt.exception(timeout=0)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -290,11 +290,13 @@ class TestClient(object):
 
 def test_retry_client():
     timeout = 5
-    client = Client(host='http://unknown-domain.com', retry_kwargs={'timeout': timeout})
+    client = Client(host='http://unknown-domain.com',
+                    user_agent_prefix=USER_AGENT_PREFIX,
+                    retry_kwargs={'timeout': timeout})
     spec = client.RecognitionSpec.retrieve('imagenet-inception-v3')
     start_time = time.time()
-    with pytest.raises(RetryError) as e:
+    with pytest.raises(RetryError):
         print(spec.data())
 
     diff = time.time() - start_time
-    assert diff > timeout and diff < timeout + 5
+    assert diff > timeout and diff < timeout + 2

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,7 +16,7 @@ from deepomatic.api.client import Client
 from deepomatic.api.http_retryer import DEFAULT_RETRY_EXP_MAX, HTTPRetryer
 from deepomatic.api.inputs import ImageInput
 from deepomatic.api.version import __title__, __version__
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError, MissingSchema
 from tenacity import RetryError, stop_after_delay
 
 from pytest_voluptuous import S
@@ -349,3 +349,10 @@ class TestClientRetry(object):
         assert last_attempt.attempt_number == 1
         last_response = last_attempt.result()
         assert 502 == last_response.status_code
+
+    def test_no_retry_blacklist_exception(self):
+         http_retryer = HTTPRetryer(stop=stop_after_delay(self.DEFAULT_TIMEOUT))
+         client = Client(http_retryer=http_retryer)
+         # check that there is no retry on exceptions from DEFAULT_RETRY_EXCEPTION_TYPES_BLACKLIST
+         with pytest.raises(MissingSchema) as exc:
+             client.http_helper.http_retryer.retry(requests.get, '')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -297,7 +297,7 @@ class TestClient(object):
 
 class TestClientRetry(object):
     DEFAULT_TIMEOUT = 2
-    DEFAULT_MIN_ATTEMPT_NUMBER = 4
+    DEFAULT_MIN_ATTEMPT_NUMBER = 3
 
     def expect_retry(self, client, timeout, min_attempt_number):
         spec = client.RecognitionSpec.retrieve('imagenet-inception-v3')  # doesn't make any http call
@@ -308,7 +308,7 @@ class TestClientRetry(object):
         diff = time.time() - start_time
         assert diff > timeout and diff < timeout + HTTPRetry.Default.RETRY_EXP_MAX
         last_attempt = exc.value.last_attempt
-        assert last_attempt.attempt_number > min_attempt_number
+        assert last_attempt.attempt_number >= min_attempt_number
         return last_attempt
 
     def test_retry_network_failure(self):


### PR DESCRIPTION
Related to #17 

- Retries on http errors (bad status code and requests exceptions)
- Fast retry, with small timeout on most requests
- Allow to override the default from a specific endpoint: network creation doesn't retry as it is an heavy request, we don't want to retry silently. Request timeout is longer
- Allow to customize the retryer when instanciating the client
