### PR TITLE
Improve integration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@ dmake.yml
 .dmake/
 DMakefile
 
-Dockerfile
+deploy/Dockerfile
 .git
 **/.gitignore
 .dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,7 @@ venv*
 
 build/
 dist/
+*.egg-info/
 
 *-coverage.xml
 *-junit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 
 build/
 dist/
+*.egg-info/
 
 *-coverage.xml
 *-junit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ install:
 
 # command to run tests
 script:
-  - pip install pytest==4.0.2 pytest-voluptuous==1.1.0 httpretty==0.9.6 # for testing
+  - pip install -r requirements.dev.txt
   - LOG_LEVEL=DEBUG python -m pytest --junit-xml=junit.xml -vv app/tests
   - LOG_LEVEL=DEBUG python app/demo.py

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
 all: release
 
-release: clean
-	python3 setup.py sdist bdist_wheel
+build: clean
+	# lint + unit tests + build egg (available in host ./dist) + test egg on python 2 and 3
+	dmake test test-egg-py2 test-egg-py3
 
 clean:
-	rm -rf build dist *.egg-info
+	rm -rf dist
 
-publish-test: release
+publish-test: build
 	# For testing, note that once one version is uploaded, you have to increment the version number or make a post release to re-upload
 	# https://www.python.org/dev/peps/pep-0440/#post-releases
 	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
-publish: release
+publish: build
 	# More info here https://packaging.python.org/tutorials/packaging-projects/
 	twine upload dist/*

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,21 +1,36 @@
 ARG BASE_IMAGE
 
-FROM ${BASE_IMAGE} as builder
+FROM ${BASE_IMAGE} as dev
 
 WORKDIR /app
 COPY . .
 # lint check
 RUN flake8 --statistics --verbose
+# prepare local dev environment, for tests execution
+RUN pip install -e .
+
+
+FROM dev as build
+
+# build egg
 RUN python setup.py bdist_wheel
 
 
-FROM ${BASE_IMAGE} as runtime
+# ideally use ROOT_IMAGE but it's not yet doable in dmake
+# => manually force root image here
+FROM python:2.7 as runtime-py2
 
 WORKDIR /app
+# don't copy egg there: use universal egg from `build-egg` service at runtime
+# prepare egg test: demo.py
+COPY --from=build /app/demo.py /app/
 
-# copy egg
-COPY --from=builder /app/dist/deepomatic_api-*.whl /tmp/
-COPY --from=builder /app/demo.py /app/
-COPY --from=builder /app/tests /app/tests
 
-RUN pip install /tmp/deepomatic_api-*.whl
+# ideally use ROOT_IMAGE but it's not yet doable in dmake
+# => manually force root image here
+FROM python:3.6 as runtime-py3
+
+WORKDIR /app
+# don't copy egg there: use universal egg from `build-egg` service at runtime
+# prepare egg test: demo.py
+COPY --from=build /app/demo.py /app/

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -2,9 +2,4 @@
 
 set -e
 
-apt-get update && apt-get install -y build-essential
-pip install -r requirements.txt
-pip install pytest==4.0.2 \
-            pytest-cov==2.6.1 \
-            pytest-voluptuous==1.1.0 \
-            httpretty==0.9.6 # for testing
+pip install -r requirements.dev.txt

--- a/dmake.yml
+++ b/dmake.yml
@@ -23,6 +23,7 @@ docker:
       root_image: python:2.7
       copy_files:
         - requirements.txt
+        - requirements.dev.txt
       install_scripts:
         - deploy/install.sh
     # Nothing changes comparing to above, except 'variant' and 'root_image'
@@ -44,6 +45,7 @@ services:
         build:
           context: .
           dockerfile: deploy/Dockerfile
+          target: dev
         base_image_variant:
           - 2.7
           - 3.4
@@ -52,9 +54,74 @@ services:
     tests:
       commands:
         - LOG_LEVEL=DEBUG pytest --junit-xml=junit.xml --cov=. --cov-report=xml:coverage.xml --cov-report html:cover -vv /app/tests
-        - LOG_LEVEL=DEBUG python /app/demo.py
       junit_report: junit.xml
       cobertura_report: coverage.xml
       html_report:
         directory: cover
         title: HTML coverage report
+
+  - service_name: build-egg
+    # unit tests must have passed on all supported platforms to build the universal egg
+    needed_services:
+      - client:2.7
+      - client:3.4
+      - client:3.5
+      - client:3.6
+    config:
+      docker_image:
+        build:
+          context: .
+          dockerfile: deploy/Dockerfile
+          target: build
+        base_image_variant: 3.6
+    tests:
+      # TODO follow up on https://github.com/Deepomatic/dmake/issues/311
+      data_volumes:
+       - container_volume: /dist/
+         source: ./dist/
+      commands:
+        # copy universal egg
+        - rm -rf /dist/*
+        - cp /app/dist/* /dist
+        - chmod -R a+w /dist
+
+  - service_name: test-egg-py2
+    needed_services:
+      - build-egg
+    config:
+      docker_image:
+        build:
+          context: .
+          dockerfile: deploy/Dockerfile
+          target: runtime-py2
+        # only used by dmake shell; bypassed by runtime-py2 Dockerfile target
+        base_image_variant:
+          - 2.7
+    tests:
+      data_volumes:
+       - container_volume: /dist/
+         source: ./dist/
+      commands:
+        - pip install /dist/deepomatic_api-*.whl
+        - LOG_LEVEL=DEBUG python /app/demo.py
+
+
+  - service_name: test-egg-py3
+    needed_services:
+      - build-egg
+    config:
+      docker_image:
+        build:
+          context: .
+          dockerfile: deploy/Dockerfile
+          target: runtime-py3
+        # only used by dmake shell; bypassed by runtime-py3 Dockerfile target
+        base_image_variant:
+          - 3.6
+    tests:
+      data_volumes:
+       - container_volume: /dist/
+         source: ./dist/
+      commands:
+        - pip install /dist/deepomatic_api-*.whl
+        - LOG_LEVEL=DEBUG python /app/demo.py

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+pytest==4.6.5
+pytest-cov==2.7.1
+pytest-voluptuous==1.1.0
+httpretty==0.9.6


### PR DESCRIPTION
- Fix .dockerignore
- Fix code coverage
  It was previously broken because it tested on the installed egg.
  We now split unit tests and egg tests (with demo.py) so code coverage
  works on source code (and still test somehow the egg).
  Also, move dev dependencies to requirements.dev.txt & bump them.
- Export egg files to host ./dist/ in test-egg services