### PR TITLE
Fix timeout exception on Network create

### DIFF
--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -43,9 +43,9 @@ API_VERSION = 0.7
 
 
 class RequestsTimeout(object):
-    FAST = (3.05, 10.)
-    MEDIUM = (3.05, 60.)
-    SLOW = (3.05, 600.)
+    FAST = 8.
+    MEDIUM = 60.
+    SLOW = 600.
 
 
 class HTTPHelper(object):


### PR DESCRIPTION
Closes #77

In fact `requests` `connect` timeout is *not* just TCP connect, but
also includes sending the whole HTTP request, which can be much
longer than 3s for Network uploads.

Before the issue is fixed in `requests` we should not fail long
uploads: stop using advanced timeouts for now.

Also decreased FAST timeout from 10 to 8 so we are guaranteed to have
at least 3 tries with the 60s timeout on tasks GET loop.