### PR TITLE
Fix content type might not be in headers

### DIFF
--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -236,7 +236,7 @@ class HTTPHelper(object):
                 # If no files are provided, requests will default to form-urlencoded content type
                 # But the API doesn't support it.
                 if not files:
-                    raise Exception("Cannot send the request as multipart without files provided.")
+                    raise DeepomaticException("Cannot send the request as multipart without files provided.")
                 # requests will build the good multipart content types with the boundaries
                 content_type = None
                 data = self.dump_json_for_multipart(data)

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -299,7 +299,8 @@ class HTTPHelper(object):
             # we asked for a stream, we let the user download it as he wants or it will load everything in RAM
             # not good for big files
             return response
-        elif 'application/json' in response.headers['Content-Type']:
+        
+        elif 'application/json' in response.headers.get('Content-Type', ''):
             return response.json()
         else:
             return response.content

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -299,7 +299,6 @@ class HTTPHelper(object):
             # we asked for a stream, we let the user download it as he wants or it will load everything in RAM
             # not good for big files
             return response
-        
         elif 'application/json' in response.headers.get('Content-Type', ''):
             return response.json()
         else:

--- a/deepomatic/api/inputs.py
+++ b/deepomatic/api/inputs.py
@@ -77,7 +77,7 @@ class AbstractInput(object):
         self._need_multipart = is_file or (is_raw and encoding == 'binary')
 
     def get_input(self):
-        raise Exception("Unimplemented")
+        raise NotImplementedError()
 
     def need_multipart(self):
         return self._need_multipart

--- a/deepomatic/api/resources/task.py
+++ b/deepomatic/api/resources/task.py
@@ -26,7 +26,8 @@ THE SOFTWARE.
 import functools
 import logging
 
-from deepomatic.api.exceptions import TaskError, TaskTimeout, HTTPRetryError, TaskRetryError
+from deepomatic.api.exceptions import (TaskError, TaskTimeout, HTTPRetryError,
+                                       TaskRetryError, DeepomaticException)
 from deepomatic.api.mixins import ListableResource
 from deepomatic.api.resource import Resource
 from deepomatic.api.utils import retry, warn_on_http_retry_error
@@ -119,7 +120,7 @@ class Task(ListableResource, Resource):
             elif is_success_status(status):
                 success_tasks.append((pos, task))
             else:
-                raise Exception("Unknown task status %s" % status)
+                raise DeepomaticException("Unknown task status %s" % status)
 
         return pending_tasks
 


### PR DESCRIPTION
It raised a KeyError if `content-type` was not in the headers and wasn't returning the response content