### PR TITLE
Seek file before retry

### DIFF
--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -219,11 +219,17 @@ class HTTPHelper(object):
                 # if so, the fileobj is in second position
                 if isinstance(f, (tuple, list)):
                     f = f[1]
+                if isinstance(f, (string_types, bytes, bytearray, int, float, bool)):
+                    continue
+                error = "Unsupported file object type '{}' for key '{}'".format(type(f), key)
                 # seek files before each retry, to avoid silently retrying with different input
                 if hasattr(f, 'seek'):
+                    if hasattr('seekable') and not f.seakable():
+                        raise DeepomaticException("{}: not seakable".format(error)
                     f.seek(0)
-                elif not isinstance(f, (string_types, bytes, bytearray)):
-                    raise DeepomaticException("Unsupported file object type '{}' for key '{}'".format(type(f), key))
+                    continue
+
+                raise DeepomaticException("{}: not a scalar or seakable.".format(error)
 
         return requests_callable(*args, files=files,
                                  timeout=requests_timeout,

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -214,10 +214,12 @@ class HTTPHelper(object):
 
         files = kwargs.pop('files', None)
         if files:
-            for f in files.values():
+            for key, f in files.items():
                 # seek files before each retry
                 if hasattr(f, 'seek'):
                     f.seek(0)
+                elif not isinstance(f, (string_types, bytes, bytearray)):
+                    raise DeepomaticException("Unsupported file type '{}' for key '{}'".format(type(f), key))
 
         return requests_callable(*args, files=files,
                                  timeout=requests_timeout,

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -215,6 +215,10 @@ class HTTPHelper(object):
         files = kwargs.pop('files', None)
         if files:
             for key, f in files.items():
+                # file can be a tuple
+                # if so, the fileobj is in second position
+                if isinstance(f, (tuple, list)):
+                    f = f[1]
                 # seek files before each retry, to avoid silently retrying with different input
                 if hasattr(f, 'seek'):
                     f.seek(0)

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -224,7 +224,7 @@ class HTTPHelper(object):
                 error = "Unsupported file object type '{}' for key '{}'".format(type(f), key)
                 # seek files before each retry, to avoid silently retrying with different input
                 if hasattr(f, 'seek'):
-                    if hasattr('seekable') and not f.seakable():
+                    if hasattr(f, 'seekable') and not f.seakable():
                         raise DeepomaticException("{}: not seakable".format(error))
                     f.seek(0)
                     continue

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -224,12 +224,12 @@ class HTTPHelper(object):
                 error = "Unsupported file object type '{}' for key '{}'".format(type(f), key)
                 # seek files before each retry, to avoid silently retrying with different input
                 if hasattr(f, 'seek'):
-                    if hasattr(f, 'seekable') and not f.seakable():
-                        raise DeepomaticException("{}: not seakable".format(error))
+                    if hasattr(f, 'seekable') and not f.seekable():
+                        raise DeepomaticException("{}: not seekable".format(error))
                     f.seek(0)
                     continue
 
-                raise DeepomaticException("{}: not a scalar or seakable.".format(error))
+                raise DeepomaticException("{}: not a scalar or seekable.".format(error))
 
         return requests_callable(*args, files=files,
                                  timeout=requests_timeout,

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -213,13 +213,12 @@ class HTTPHelper(object):
         requests_timeout = kwargs.pop('timeout', self.requests_timeout)
 
         files = kwargs.pop('files', None)
-        print(files)
         if files:
             for f in files.values():
                 # seek files before each retry
                 if hasattr(f, 'seek'):
                     f.seek(0)
-        print("SENDING REQUEST")
+
         return requests_callable(*args, files=files,
                                  timeout=requests_timeout,
                                  verify=self.verify_ssl,

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -225,11 +225,11 @@ class HTTPHelper(object):
                 # seek files before each retry, to avoid silently retrying with different input
                 if hasattr(f, 'seek'):
                     if hasattr('seekable') and not f.seakable():
-                        raise DeepomaticException("{}: not seakable".format(error)
+                        raise DeepomaticException("{}: not seakable".format(error))
                     f.seek(0)
                     continue
 
-                raise DeepomaticException("{}: not a scalar or seakable.".format(error)
+                raise DeepomaticException("{}: not a scalar or seakable.".format(error))
 
         return requests_callable(*args, files=files,
                                  timeout=requests_timeout,

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -219,7 +219,7 @@ class HTTPHelper(object):
                 if hasattr(f, 'seek'):
                     f.seek(0)
                 elif not isinstance(f, (string_types, bytes, bytearray)):
-                    raise DeepomaticException("Unsupported file type '{}' for key '{}'".format(type(f), key))
+                    raise DeepomaticException("Unsupported file object type '{}' for key '{}'".format(type(f), key))
 
         return requests_callable(*args, files=files,
                                  timeout=requests_timeout,

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -215,7 +215,7 @@ class HTTPHelper(object):
         files = kwargs.pop('files', None)
         if files:
             for key, f in files.items():
-                # seek files before each retry
+                # seek files before each retry, to avoid silently retrying with different input
                 if hasattr(f, 'seek'):
                     f.seek(0)
                 elif not isinstance(f, (string_types, bytes, bytearray)):

--- a/deepomatic/api/http_helper.py
+++ b/deepomatic/api/http_helper.py
@@ -219,7 +219,7 @@ class HTTPHelper(object):
                 # if so, the fileobj is in second position
                 if isinstance(f, (tuple, list)):
                     f = f[1]
-                if isinstance(f, (string_types, bytes, bytearray, int, float, bool)):
+                if f is None or isinstance(f, (string_types, bytes, bytearray, int, float, bool)):
                     continue
                 error = "Unsupported file object type '{}' for key '{}'".format(type(f), key)
                 # seek files before each retry, to avoid silently retrying with different input

--- a/deepomatic/api/version.py
+++ b/deepomatic/api/version.py
@@ -1,6 +1,6 @@
 __title__ = 'deepomatic-api'
 __description__ = 'Deepomatic API client'
-__version__ = '0.9.2'
+__version__ = '0.9.3'
 __author__ = 'deepomatic'
 __author_email__ = 'support@deepomatic.com'
 __url__ = 'https://github.com/deepomatic/deepomatic-client-python'

--- a/demo.py
+++ b/demo.py
@@ -359,7 +359,7 @@ def download_file(url):
     filename = os.path.join(tempfile.gettempdir(),
                             hashlib.sha1(url.encode()).hexdigest() + ext)
     if os.path.exists(filename):  # avoid redownloading
-        logger.info("Skipping download of {}: file already exist in ".format(url, filename))
+        logger.info("Skipping download of {}: file already exist in {}".format(url, filename))
         return filename
     r = requests.get(url, stream=True)
     r.raise_for_status()

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,3 +3,4 @@ pytest==4.6.5
 pytest-cov==2.7.1
 pytest-voluptuous==1.1.0
 httpretty==0.9.6
+flake8==3.8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ promise>=2.1,<3
 six>=1.10.0,<2
 requests>=2.19.0,<3  # will not work below in python3
 tenacity>=5.1,<6
-flake8>=3.7,<4

--- a/setup.py
+++ b/setup.py
@@ -2,16 +2,8 @@ import os
 import io
 from setuptools import find_packages, setup
 
-try:
-    # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError:
-    # for pip <= 9.0.3
-    from pip.req import parse_requirements
-
 
 here = os.path.abspath(os.path.dirname(__file__))
-
 
 about = {}
 with io.open(os.path.join(here, 'deepomatic', 'api', 'version.py'), 'r', encoding='utf-8') as f:
@@ -24,7 +16,8 @@ with io.open(os.path.join(here, 'README.md'), 'r', encoding='utf-8') as readme:
 os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 # Read requirements
-install_reqs = parse_requirements(os.path.join(here, 'requirements.txt'), session='hack')
+with io.open(os.path.join(here, 'requirements.txt'), encoding='utf-8') as f:
+    requirements = f.readlines()
 
 namespaces = ['deepomatic']
 
@@ -43,7 +36,7 @@ setup(
     long_description=README,
     long_description_content_type='text/markdown',
     data_files=[('', ['requirements.txt'])],
-    install_requires=[str(ir.req) for ir in install_reqs],
+    install_requires=requirements,
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
     classifiers=[
         'Operating System :: OS Independent',


### PR DESCRIPTION
When a retry is done due to an API error, the files where not seeked back to the beginning, thus the second time we were sending an empty file.

Also fixed pip install requirements