### PR TITLE
[Add] Allow tenacity to upgrade to 8.* version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy>=1.10.0,<2
 promise>=2.1,<3
 six>=1.10.0,<2
 requests>=2.19.0,<3  # will not work below in python3
-tenacity>=5.1,<6
+tenacity>=5.1,<9


### PR DESCRIPTION
We need to upgrade tenacity to a higher version in order to get rid of deprecated warning in Vesta.

We can upgrade to 8.* version as the changes described in the changelog are not impacting this repo.
https://tenacity.readthedocs.io/en/latest/changelog.html