### PR TITLE
Improve retry error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,8 @@ all: release
 build: clean
 	# lint + unit tests + build egg (available in host ./dist)
 	dmake test build-egg
-	# + test egg on python 2 and 3 using egg from host
-	dmake test -s test-egg-py2:2.7
-	dmake test -s test-egg-py3:3.6
+	# + test egg on python 3 using egg from host
+	dmake test -s test-egg-py3:3.8
 
 clean:
 	rm -rf dist

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This client have been made in order to help you integrating our services within your apps in python.
 
-Tested on python 2.7, 3.4, 3.5, 3.6.
+Tested on python 3.8, 3.9, 3.10, 3.11.
 
 # API Documentation
 

--- a/deepomatic/api/exceptions.py
+++ b/deepomatic/api/exceptions.py
@@ -24,36 +24,27 @@ THE SOFTWARE.
 
 import json
 from tenacity import RetryError
+from requests import Response
 
-
-###############################################################################
 
 class DeepomaticException(Exception):
     def __init__(self, msg):
         super(DeepomaticException, self).__init__(msg)
-
-###############################################################################
 
 
 class CredentialsNotFound(DeepomaticException):
     pass
 
 
-###############################################################################
-
 class UnimplementedException(DeepomaticException):
     def __init__(self, msg):
         super(UnimplementedException, self).__init__(msg)
 
 
-###############################################################################
-
 class NoData(DeepomaticException):
     def __init__(self):
         super(NoData, self).__init__("No data !! You may need to call '.retrieve()' ?")
 
-
-###############################################################################
 
 class BadStatus(DeepomaticException):
     """
@@ -93,8 +84,6 @@ class ServerError(BadStatus):
     pass
 
 
-###############################################################################
-
 class TaskError(DeepomaticException):
     def __init__(self, task):
         self.task = task
@@ -106,8 +95,6 @@ class TaskError(DeepomaticException):
         return self.task['id']
 
 
-###############################################################################
-
 class TaskTimeout(DeepomaticException):
     def __init__(self, task, retry_error=None):
         self.task = task
@@ -118,9 +105,6 @@ class TaskTimeout(DeepomaticException):
 
     def get_task_id(self):
         return self.task['id']
-
-
-###############################################################################
 
 
 class HTTPRetryError(RetryError):

--- a/deepomatic/api/exceptions.py
+++ b/deepomatic/api/exceptions.py
@@ -119,7 +119,7 @@ class HTTPRetryError(RetryError):
                 last_request = last_result.request
                 msg += f"a Response <status_code={last_result.status_code} method={last_request.method.upper()} url={last_request.url}>"
             else:
-                msg += str(last_result)
+                return super().__str__()
         return msg
 
 

--- a/deepomatic/api/exceptions.py
+++ b/deepomatic/api/exceptions.py
@@ -26,6 +26,7 @@ import json
 from tenacity import RetryError
 from requests import Response
 
+
 class DeepomaticException(Exception):
     def __init__(self, msg):
         super(DeepomaticException, self).__init__(msg)

--- a/deepomatic/api/exceptions.py
+++ b/deepomatic/api/exceptions.py
@@ -24,7 +24,6 @@ THE SOFTWARE.
 
 import json
 from tenacity import RetryError
-from requests import Response
 
 
 class DeepomaticException(Exception):

--- a/deepomatic/api/http_retry.py
+++ b/deepomatic/api/http_retry.py
@@ -55,7 +55,7 @@ class HTTPRetry(object):
         RETRY_TIMEOUT = 60
         RETRY_EXP_MAX = 10.
         RETRY_EXP_MULTIPLIER = 0.5
-        RETRY_STATUS_CODES = [500, 502, 503, 504]
+        RETRY_STATUS_CODES = [502, 503, 504]
         RETRY_EXCEPTION_TYPES = (RequestException, )
         RETRY_EXCEPTION_TYPES_BLACKLIST = (ValueError, ProxyError, TooManyRedirects, URLRequired)
 

--- a/deepomatic/api/inference.py
+++ b/deepomatic/api/inference.py
@@ -5,7 +5,7 @@ from deepomatic.api.inputs import format_inputs
 
 class InferenceResource(object):
     def inference(self, return_task=False, wait_task=True, **kwargs):
-        assert(self._pk is not None)
+        assert (self._pk is not None)
 
         inputs = kwargs.pop('inputs', None)
         if inputs is None:

--- a/deepomatic/api/inputs.py
+++ b/deepomatic/api/inputs.py
@@ -32,7 +32,7 @@ from deepomatic.api.exceptions import DeepomaticException
 ###############################################################################
 
 def format_inputs(inputs, data):
-    assert(isinstance(inputs, list))
+    assert (isinstance(inputs, list))
 
     data = copy.deepcopy(data)
     files = {}

--- a/deepomatic/api/mixins.py
+++ b/deepomatic/api/mixins.py
@@ -58,7 +58,7 @@ class UpdateOnlyArg(Arg):
 
 class UpdatableResource(object):
     def update(self, replace=False, content_type='application/json', files=None, **kwargs):
-        assert(self._pk is not None)
+        assert (self._pk is not None)
 
         if self._helper.check_query_parameters:
             for arg_name in kwargs:
@@ -78,7 +78,7 @@ class UpdatableResource(object):
 
 class DeletableResource(object):
     def delete(self):
-        assert(self._pk is not None)
+        assert (self._pk is not None)
         return self._helper.delete(self._uri(pk=self._pk))
 
 

--- a/deepomatic/api/resource.py
+++ b/deepomatic/api/resource.py
@@ -47,7 +47,7 @@ class Resource(object):
         return self.__class__(self._helper, pk=pk)
 
     def refresh(self):
-        assert(self._pk is not None)
+        assert (self._pk is not None)
         self._data = self._helper.get(self._uri(pk=self._pk))
         return self
 

--- a/deepomatic/api/resources/recognition.py
+++ b/deepomatic/api/resources/recognition.py
@@ -55,7 +55,7 @@ class RecognitionSpec(ListableResource,
         return '/recognition/public/' if public else '/recognition/specs/'
 
     def versions(self, offset=0, limit=100):
-        assert(self._pk is not None)
+        assert (self._pk is not None)
         return ResourceList(RecognitionVersion, self._helper, self._uri(pk=self._pk, suffix='versions'), offset, limit)
 
 

--- a/deepomatic/api/resources/task.py
+++ b/deepomatic/api/resources/task.py
@@ -77,7 +77,7 @@ class Task(ListableResource, Resource):
         """
         Returns a list of tasks
         """
-        assert(isinstance(task_ids, list))
+        assert (isinstance(task_ids, list))
         return super(Task, self).list(task_ids=task_ids)
 
     def wait(self, **retry_kwargs):

--- a/demo.py
+++ b/demo.py
@@ -343,11 +343,11 @@ def demo(client=None):
 
     # pending_tasks, error_tasks and success_tasks contains the original offset of the input parameter tasks
     for pos, pending in pending_tasks:
-        assert(tasks[pos].pk == pending.pk)
+        assert (tasks[pos].pk == pending.pk)
     for pos, err in error_tasks:
-        assert(tasks[pos].pk == err.pk)
+        assert (tasks[pos].pk == err.pk)
     for pos, success in success_tasks:
-        assert(tasks[pos].pk == success.pk)
+        assert (tasks[pos].pk == success.pk)
 
 ###########
 # Helpers #

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -18,17 +18,7 @@ RUN python setup.py bdist_wheel
 
 # ideally use ROOT_IMAGE but it's not yet doable in dmake
 # => manually force root image here
-FROM python:2.7 as runtime-py2
-
-WORKDIR /app
-# don't copy egg there: use universal egg from `build-egg` service at runtime
-# prepare egg test: demo.py
-COPY --from=build /app/demo.py /app/
-
-
-# ideally use ROOT_IMAGE but it's not yet doable in dmake
-# => manually force root image here
-FROM python:3.6 as runtime-py3
+FROM python:3.8 as runtime-py3
 
 WORKDIR /app
 # don't copy egg there: use universal egg from `build-egg` service at runtime

--- a/dmake.yml
+++ b/dmake.yml
@@ -11,7 +11,6 @@ env:
     master:
       source: ${DEEPOMATIC_CONFIG_DIR}/prod.sh
 
-
 docker:
   base_image:
     # This first item is a YAML template named "base_image"
@@ -19,8 +18,8 @@ docker:
     # "- <<: *base_image" as used below.
     - &base_image
       name: deepomatic-client-python
-      variant: '2.7'
-      root_image: python:2.7
+      variant: '3.8'
+      root_image: python:3.8
       copy_files:
         - requirements.txt
         - requirements.dev.txt
@@ -28,15 +27,14 @@ docker:
         - deploy/install.sh
     # Nothing changes comparing to above, except 'variant' and 'root_image'
     - <<: *base_image
-      variant: '3.4'
-      root_image: python:3.4
+      variant: '3.9'
+      root_image: python:3.9
     - <<: *base_image
-      variant: '3.5'
-      root_image: python:3.5
+      variant: '3.10'
+      root_image: python:3.10
     - <<: *base_image
-      variant: '3.6'
-      root_image: python:3.6
-
+      variant: '3.11'
+      root_image: python:3.11
 
 services:
   - service_name: client
@@ -47,10 +45,10 @@ services:
           dockerfile: deploy/Dockerfile
           target: dev
         base_image_variant:
-          - '2.7'
-          - '3.4'
-          - '3.5'
-          - '3.6'
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
     tests:
       commands:
         - LOG_LEVEL=DEBUG pytest --junit-xml=junit.xml --cov=. --cov-report=xml:coverage.xml --cov-report html:cover -vv /app/tests
@@ -63,17 +61,17 @@ services:
   - service_name: build-egg
     # unit tests must have passed on all supported platforms to build the universal egg
     needed_services:
-      - client:2.7
-      - client:3.4
-      - client:3.5
-      - client:3.6
+      - client:3.8
+      - client:3.9
+      - client:3.10
+      - client:3.11
     config:
       docker_image:
         build:
           context: .
           dockerfile: deploy/Dockerfile
           target: build
-        base_image_variant: '3.6'
+        base_image_variant: '3.8'
     tests:
       # TODO follow up on https://github.com/Deepomatic/dmake/issues/311
       data_volumes:
@@ -84,27 +82,6 @@ services:
         - rm -rf /dist/*
         - cp /app/dist/* /dist
         - chmod -R a+w /dist
-
-  - service_name: test-egg-py2
-    needed_services:
-      - build-egg
-    config:
-      docker_image:
-        build:
-          context: .
-          dockerfile: deploy/Dockerfile
-          target: runtime-py2
-        # only used by dmake shell; bypassed by runtime-py2 Dockerfile target
-        base_image_variant:
-          - '2.7'
-    tests:
-      data_volumes:
-       - container_volume: /dist/
-         source: ./dist/
-      commands:
-        - pip install /dist/deepomatic_api-*.whl
-        - LOG_LEVEL=DEBUG python /app/demo.py
-
 
   - service_name: test-egg-py3
     needed_services:
@@ -117,7 +94,7 @@ services:
           target: runtime-py3
         # only used by dmake shell; bypassed by runtime-py3 Dockerfile target
         base_image_variant:
-          - '3.6'
+          - '3.8'
     tests:
       data_volumes:
        - container_volume: /dist/

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
-pytest==4.6.5
-pytest-cov==2.7.1
-pytest-voluptuous==1.1.0
-httpretty==0.9.6
-flake8==3.8.4
+pytest==7.4.3
+pytest-cov==4.1.0
+pytest-voluptuous==1.2.0
+httpretty==1.1.4
+flake8==6.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 numpy>=1.10.0,<2
-promise>=2.1,<3
 six>=1.10.0,<2
 requests>=2.19.0,<3  # will not work below in python3
 tenacity>=5.1,<9

--- a/setup.py
+++ b/setup.py
@@ -37,16 +37,14 @@ setup(
     long_description_content_type='text/markdown',
     data_files=[('', ['requirements.txt'])],
     install_requires=requirements,
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=3.8.*",
     classifiers=[
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ]
 )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -437,7 +437,6 @@ class TestClientRetry(object):
             last_exception = retry_error.last_attempt.exception(timeout=0)
             assert isinstance(last_exception, HTTPRetryError)
             assert 502 == last_exception.last_attempt.result().status_code
-            assert str(last_exception)
 
     def test_no_retry_blacklist_exception(self):
         client = self.get_client_with_retry()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -352,9 +352,12 @@ class TestClientRetry(object):
         with pytest.raises(HTTPRetryError) as exc:
             print(spec.data())  # does make a http call
 
-        assert str(exc.value).startswith("""
-        Last attempt was an exception <class 'requests.exceptions.ConnectionError'> "HTTPConnectionPool(host='invalid-domain.deepomatic.com', port=80): Max retries exceeded with url: /v0.7/recognition/public/imagenet-inception-v3/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at
-        """.strip())
+        assert str(exc.value).startswith(
+            """Last attempt was an exception <class 'requests.exceptions.ConnectionError'> \""""
+            """HTTPConnectionPool(host='invalid-domain.deepomatic.com', port=80): Max retries exceeded with url: """
+            """/v0.7/recognition/public/imagenet-inception-v3/ (Caused by NewConnectionError"""
+            """('<urllib3.connection.HTTPConnection object at"""
+        )
         assert str(exc.value).endswith("""
         >: Failed to establish a new connection: [Errno -2] Name or service not known',))"
         """.strip())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -352,14 +352,15 @@ class TestClientRetry(object):
         with pytest.raises(HTTPRetryError) as exc:
             print(spec.data())  # does make a http call
 
+        # raise Exception(exc.value)
         assert str(exc.value).startswith(
             """Last attempt was an exception <class 'requests.exceptions.ConnectionError'> \""""
             """HTTPConnectionPool(host='invalid-domain.deepomatic.com', port=80): Max retries exceeded with url: """
-            """/v0.7/recognition/public/imagenet-inception-v3/ (Caused by NewConnectionError"""
-            """('<urllib3.connection.HTTPConnection object at"""
+            """/v0.7/recognition/public/imagenet-inception-v3/ (Caused by NameResolutionError"""
+            """("<urllib3.connection.HTTPConnection object at"""
         )
         assert str(exc.value).endswith("""
-        >: Failed to establish a new connection: [Errno -2] Name or service not known',))"
+        >: Failed to resolve 'invalid-domain.deepomatic.com' ([Errno -2] Name or service not known)"))"
         """.strip())
 
     def test_retry_bad_status_code(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -348,6 +348,29 @@ class TestClientRetry(object):
         assert isinstance(exc, ConnectionError)
         assert 'Name or service not known' in str(exc)
 
+        spec = client.RecognitionSpec.retrieve('imagenet-inception-v3')  # doesn't make any http call
+        with pytest.raises(HTTPRetryError) as exc:
+            print(spec.data())  # does make a http call
+
+        assert str(exc.value).startswith("""
+        Last attempt was an exception <class 'requests.exceptions.ConnectionError'> "HTTPConnectionPool(host='invalid-domain.deepomatic.com', port=80): Max retries exceeded with url: /v0.7/recognition/public/imagenet-inception-v3/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at
+        """.strip())
+        assert str(exc.value).endswith("""
+        >: Failed to establish a new connection: [Errno -2] Name or service not known',))"
+        """.strip())
+
+    def test_retry_bad_status_code(self):
+        client = get_client(host='https://httpbin.org', version=None)
+        with httpretty.enabled():
+            httpretty.register_uri(
+                httpretty.GET,
+                re.compile(r'https?://.*?/?'),
+                status=502,
+            )  # to avoid flakyness we prefer to mock even though httpbin is done for that
+            with pytest.raises(HTTPRetryError) as retry_error:
+                client.http_helper.get('/status/502')
+            assert str(retry_error.value) == "Last attempt was a Response <status_code=502 method=GET url=https://httpbin.org//status/502>"
+
     def register_uri(self, methods, status):
         for method in methods:
             httpretty.register_uri(
@@ -410,6 +433,7 @@ class TestClientRetry(object):
             last_exception = retry_error.last_attempt.exception(timeout=0)
             assert isinstance(last_exception, HTTPRetryError)
             assert 502 == last_exception.last_attempt.result().status_code
+            assert str(last_exception)
 
     def test_no_retry_blacklist_exception(self):
         client = self.get_client_with_retry()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -294,11 +294,11 @@ class TestClient(object):
 
         # pending_tasks, error_tasks and success_tasks contains the original offset of the input parameter tasks
         for pos, pending in pending_tasks:
-            assert(tasks[pos].pk == pending.pk)
+            assert (tasks[pos].pk == pending.pk)
         for pos, err in error_tasks:
-            assert(tasks[pos].pk == err.pk)
+            assert (tasks[pos].pk == err.pk)
         for pos, success in success_tasks:
-            assert(tasks[pos].pk == success.pk)
+            assert (tasks[pos].pk == success.pk)
             assert inference_schema(2, 0, 'golden retriever', 0.8) == success['data']
 
         # Task* str(): oneliners (easier to parse in log tooling)


### PR DESCRIPTION
- Overriding `__str__` of `HTTPRetryError` to get a more informative error especially when having a bad status code
- Removing retry on 500 codes: they are 95% of the time programming errors that will retry until timeout and saturate the backends. Instead all errors that are transient and raised as 500 on backend side should be converted into 502-503.
- Removed python 2.7 support
- Bump dev dependencies

Close https://github.com/Deepomatic/deepomatic-client-python/issues/96

#### Before

```
HTTPRetryError[<Future at 0x7fb778751640 state=finished returned Response>]
```

#### After

```
Last attempt was a Response <status_code=502 method=GET url=https://httpbin.org//status/502>
```